### PR TITLE
Replace crust with `tx-crust`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug encountered while using tx-chain ecosystem (txd, crust etc)
+description: Report a bug encountered while using tx-chain ecosystem (txd, txcrust etc)
 labels: []
 body:
   - type: textarea
@@ -33,7 +33,7 @@ body:
       value: |
         - Full OS version: [e.g. macOS 12.0.1]
         - Docker version: (you can get it by executing `docker version`)
-        - tx-chain & crust git commit sha: (you can get it by executing `git rev-parse --short HEAD` in an appropriate repo)
+        - tx-chain & tx-crust git commit sha: (you can get it by executing `git rev-parse --short HEAD` in an appropriate repo)
         - Other (if applicable)
     validations:
       required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,12 @@ jobs:
             ~/.cache/go-build
             ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-      - name: Setup crust cache
+      - name: Setup tx-crust cache
         uses: actions/cache@v4
         with:
           path: |
-            ~/.cache/crust
-          key: ${{ runner.os }}-crust-${{ hashFiles('build/go.sum') }}
+            ~/.cache/tx-crust
+          key: ${{ runner.os }}-tx-crust-${{ hashFiles('build/go.sum') }}
       - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: |
@@ -134,7 +134,7 @@ jobs:
             ${{ github.workspace }}/integration-tests/contracts/**/artifacts/*
             ${{ github.workspace }}/x/asset/ft/keeper/test-contracts/**/artifacts/*
             ${{ github.workspace }}/x/dex/keeper/test-contracts/**/artifacts/*
-            ~/.cache/crust/wasm/code-hashes.json
+            ~/.cache/tx-crust/wasm/code-hashes.json
           key: ${{ runner.os }}-cache-smart-contracts-${{ hashFiles('**/*.rs', '**/Cargo.toml', '**/Cargo.lock') }}
         if: ${{ matrix.wasm-cache }}
       - name: Run ${{ matrix.ci_step }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To stop and purge the testing environment run:
 $ make znet-remove
 ```
 
-To get all the details on how `znet` tool might be used, go to the <!-- markdown-link-check-disable -->[crust repository](https://github.com/tokenize-x/tx-chain)<!-- markdown-link-check-enable -->.
+To get all the details on how `znet` tool might be used, go to the <!-- markdown-link-check-disable -->[tx-crust repository](https://github.com/tokenize-x/tx-crust)<!-- markdown-link-check-enable -->.
 
 ### Interact with the local chain
 

--- a/bin/tx-chain-builder
+++ b/bin/tx-chain-builder
@@ -22,7 +22,7 @@ fi
 case "$1" in
 
    "znet")
-      MODULE="github.com/tokenize-x/crust/znet"
+      MODULE="github.com/tokenize-x/tx-crust/znet"
       VERSION_TMPL='{{ if or (.Replace) (eq .Version "") }}devel{{ else }}{{ .Version }}{{ end }}'
       ZNET_VERSION=$(go list -m -f "$VERSION_TMPL" "$MODULE")
       ZNET_BIN="$REPO/bin/.cache/znet-${ZNET_VERSION}"

--- a/build/cmd/builder/main.go
+++ b/build/cmd/builder/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"github.com/tokenize-x/crust/build"
-	"github.com/tokenize-x/crust/build/tools"
 	selfBuild "github.com/tokenize-x/tx-chain/build"
 	selfTools "github.com/tokenize-x/tx-chain/build/tools"
+	"github.com/tokenize-x/tx-crust/build"
+	"github.com/tokenize-x/tx-crust/build/tools"
 )
 
 func init() {

--- a/build/cmd/znet/main.go
+++ b/build/cmd/znet/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/tokenize-x/crust/znet/infra"
-	"github.com/tokenize-x/crust/znet/pkg/znet"
 	txchainbuild "github.com/tokenize-x/tx-chain/build/tx-chain"
+	"github.com/tokenize-x/tx-crust/znet/infra"
+	"github.com/tokenize-x/tx-crust/znet/pkg/znet"
 )
 
 func main() {

--- a/build/go.mod
+++ b/build/go.mod
@@ -32,9 +32,9 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.49.1
-	github.com/tokenize-x/tx-chain/v6 v6.0.0-20251008070942-1a6bf2112978
-	github.com/tokenize-x/tx-crust v0.0.0-20251010121351-deccc41f2f34
-	github.com/tokenize-x/tx-crust/znet v0.0.0-20251010121351-deccc41f2f34
+	github.com/tokenize-x/tx-chain/v6 v6.0.0-20251008161952-cdb7ab3aef61
+	github.com/tokenize-x/tx-crust v0.0.0-20251010134820-0b8b825fb2ca
+	github.com/tokenize-x/tx-crust/znet v0.0.0-20251010134820-0b8b825fb2ca
 	github.com/tokenize-x/tx-tools v0.0.0-20251006151522-f6df01ec2033
 )
 

--- a/build/go.mod
+++ b/build/go.mod
@@ -28,18 +28,13 @@ replace (
 	nhooyr.io/websocket => nhooyr.io/websocket v1.8.17
 )
 
-replace (
-	github.com/tokenize-x/crust => github.com/tokenize-x/tx-crust v0.0.0-20251008134921-0f5151bf8892
-	github.com/tokenize-x/crust/znet => github.com/tokenize-x/tx-crust/znet v0.0.0-20251008134921-0f5151bf8892
-)
-
 require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.49.1
-	github.com/tokenize-x/crust v0.0.0-20251008134921-0f5151bf8892
-	github.com/tokenize-x/crust/znet v0.0.0-20251008134921-0f5151bf8892
 	github.com/tokenize-x/tx-chain/v6 v6.0.0-20251008070942-1a6bf2112978
+	github.com/tokenize-x/tx-crust v0.0.0-20251010121351-deccc41f2f34
+	github.com/tokenize-x/tx-crust/znet v0.0.0-20251010121351-deccc41f2f34
 	github.com/tokenize-x/tx-tools v0.0.0-20251006151522-f6df01ec2033
 )
 

--- a/build/go.sum
+++ b/build/go.sum
@@ -1650,10 +1650,10 @@ github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e/go.mod h1:
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
 github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tokenize-x/tx-crust v0.0.0-20251008134921-0f5151bf8892 h1:52xE2S14MCS9ARt7QH0/1XDI2Gejft8q5IC2+e4Ojck=
-github.com/tokenize-x/tx-crust v0.0.0-20251008134921-0f5151bf8892/go.mod h1:E6p/FMk8d7ndDCJQQ/8EjzghWylOrWw5tP5sXDAMF9o=
-github.com/tokenize-x/tx-crust/znet v0.0.0-20251008134921-0f5151bf8892 h1:hFPHLr+2hyQPxdngmkYiz+iq0al4UzeP1UlwLzpatEE=
-github.com/tokenize-x/tx-crust/znet v0.0.0-20251008134921-0f5151bf8892/go.mod h1:DC5QGaW9pGWrH5BBW9nHyqX2kFGVqsMxv4/ehIPSPTo=
+github.com/tokenize-x/tx-crust v0.0.0-20251010121351-deccc41f2f34 h1:JMR/C3zQfee4mEVn4xs30NU+FcVTVCDF+wFQM+MWKfc=
+github.com/tokenize-x/tx-crust v0.0.0-20251010121351-deccc41f2f34/go.mod h1:uBS4jcaHdXgfZTGYdpGm00EvHtramk3+W1g0EF6WI3E=
+github.com/tokenize-x/tx-crust/znet v0.0.0-20251010121351-deccc41f2f34 h1:rgSyEEXLR/nl+dR1B4raVR4qjv9j3wXhfEMwA9aJDUo=
+github.com/tokenize-x/tx-crust/znet v0.0.0-20251010121351-deccc41f2f34/go.mod h1:8/dMaZS4vrb+KZXEPCy963XaDI77XTY7RAV3QemCKpU=
 github.com/tokenize-x/tx-tools v0.0.0-20251006151522-f6df01ec2033 h1:1++kosP83GjVa85RkTBxkzI3qNKPWp0uIRn4UiFQuPY=
 github.com/tokenize-x/tx-tools v0.0.0-20251006151522-f6df01ec2033/go.mod h1:tnc0L7WkOv6kah53Wl17fcG8G2MCPGotP1v2ezB/a/g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/build/go.sum
+++ b/build/go.sum
@@ -1650,10 +1650,10 @@ github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e/go.mod h1:
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
 github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tokenize-x/tx-crust v0.0.0-20251010121351-deccc41f2f34 h1:JMR/C3zQfee4mEVn4xs30NU+FcVTVCDF+wFQM+MWKfc=
-github.com/tokenize-x/tx-crust v0.0.0-20251010121351-deccc41f2f34/go.mod h1:uBS4jcaHdXgfZTGYdpGm00EvHtramk3+W1g0EF6WI3E=
-github.com/tokenize-x/tx-crust/znet v0.0.0-20251010121351-deccc41f2f34 h1:rgSyEEXLR/nl+dR1B4raVR4qjv9j3wXhfEMwA9aJDUo=
-github.com/tokenize-x/tx-crust/znet v0.0.0-20251010121351-deccc41f2f34/go.mod h1:8/dMaZS4vrb+KZXEPCy963XaDI77XTY7RAV3QemCKpU=
+github.com/tokenize-x/tx-crust v0.0.0-20251010134820-0b8b825fb2ca h1:tttxeF9gQOxOFCoNzp7oTe/yZP9m33NOKWR5FBGeYxw=
+github.com/tokenize-x/tx-crust v0.0.0-20251010134820-0b8b825fb2ca/go.mod h1:uBS4jcaHdXgfZTGYdpGm00EvHtramk3+W1g0EF6WI3E=
+github.com/tokenize-x/tx-crust/znet v0.0.0-20251010134820-0b8b825fb2ca h1:atzEWgvdLZT4zv4RyLf2VhGYL4Tyad1hNaxv4/SUky8=
+github.com/tokenize-x/tx-crust/znet v0.0.0-20251010134820-0b8b825fb2ca/go.mod h1:GNXeqyNkqv2ob4nMNgtVhFxv5eSQVq7xnCypgIJzWyI=
 github.com/tokenize-x/tx-tools v0.0.0-20251006151522-f6df01ec2033 h1:1++kosP83GjVa85RkTBxkzI3qNKPWp0uIRn4UiFQuPY=
 github.com/tokenize-x/tx-tools v0.0.0-20251006151522-f6df01ec2033/go.mod h1:tnc0L7WkOv6kah53Wl17fcG8G2MCPGotP1v2ezB/a/g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/build/index.go
+++ b/build/index.go
@@ -3,17 +3,17 @@ package build
 import (
 	"context"
 
-	"github.com/tokenize-x/crust/build/crust"
-	"github.com/tokenize-x/crust/build/golang"
-	"github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
 	txchain "github.com/tokenize-x/tx-chain/build/tx-chain"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	"github.com/tokenize-x/tx-crust/build/tools"
+	txcrust "github.com/tokenize-x/tx-crust/build/tx-crust"
+	"github.com/tokenize-x/tx-crust/build/types"
 )
 
 // Commands is a definition of commands available in build system.
 var Commands = map[string]types.Command{
 	"build/me":   {Fn: txchain.BuildBuilder, Description: "Builds the builder"},
-	"build/znet": {Fn: crust.BuildZNet, Description: "Builds znet binary"},
+	"build/znet": {Fn: txcrust.BuildZNet, Description: "Builds znet binary"},
 	"build": {Fn: func(ctx context.Context, deps types.DepsFunc) error {
 		deps(
 			txchain.BuildTXd,

--- a/build/tools/tools.go
+++ b/build/tools/tools.go
@@ -3,8 +3,8 @@ package tools
 import (
 	"context"
 
-	"github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
+	"github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 )
 
 const (
@@ -405,7 +405,7 @@ func EnsureProtocGenBufBreaking(ctx context.Context, deps types.DepsFunc) error 
 	return tools.Ensure(ctx, ProtocGenBufBreaking, tools.TargetPlatformLocal)
 }
 
-// EnsureBinary installs gaiad binary to crust cache.
+// EnsureBinary installs gaiad binary to tx-crust cache.
 func EnsureBinary(ctx context.Context, deps types.DepsFunc) error {
 	return tools.Ensure(ctx, Gaia, tools.TargetPlatformLocal)
 }

--- a/build/tx-chain/build-builder.go
+++ b/build/tx-chain/build-builder.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/tokenize-x/crust/build/golang"
-	"github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	"github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 	"github.com/tokenize-x/tx-tools/pkg/must"
 )
 

--- a/build/tx-chain/build.go
+++ b/build/tx-chain/build.go
@@ -9,15 +9,15 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tokenize-x/crust/build/config"
-	"github.com/tokenize-x/crust/build/docker"
-	dockerbasic "github.com/tokenize-x/crust/build/docker/basic"
-	"github.com/tokenize-x/crust/build/git"
-	"github.com/tokenize-x/crust/build/golang"
-	"github.com/tokenize-x/crust/build/lint"
-	crusttools "github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
 	txchaintools "github.com/tokenize-x/tx-chain/build/tools"
+	"github.com/tokenize-x/tx-crust/build/config"
+	"github.com/tokenize-x/tx-crust/build/docker"
+	dockerbasic "github.com/tokenize-x/tx-crust/build/docker/basic"
+	"github.com/tokenize-x/tx-crust/build/git"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	"github.com/tokenize-x/tx-crust/build/lint"
+	txcrusttools "github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 	"github.com/tokenize-x/tx-tools/pkg/libexec"
 )
 
@@ -55,7 +55,7 @@ func BuildTXdLocally(ctx context.Context, deps types.DepsFunc) error {
 	}
 
 	return golang.Build(ctx, deps, golang.BinaryBuildConfig{
-		TargetPlatform: crusttools.TargetPlatformLocal,
+		TargetPlatform: txcrusttools.TargetPlatformLocal,
 		PackagePath:    "cmd/txd",
 		BinOutputPath:  binaryPath,
 		CGOEnabled:     true,
@@ -66,21 +66,21 @@ func BuildTXdLocally(ctx context.Context, deps types.DepsFunc) error {
 
 // BuildTXdInDocker builds txd in docker.
 func BuildTXdInDocker(ctx context.Context, deps types.DepsFunc) error {
-	return buildTXdInDocker(ctx, deps, crusttools.TargetPlatformLinuxLocalArchInDocker, []string{goCoverFlag})
+	return buildTXdInDocker(ctx, deps, txcrusttools.TargetPlatformLinuxLocalArchInDocker, []string{goCoverFlag})
 }
 
 // BuildGaiaDockerImage builds docker image of the gaia.
 func BuildGaiaDockerImage(ctx context.Context, deps types.DepsFunc) error {
-	if err := crusttools.Ensure(ctx, txchaintools.Gaia, crusttools.TargetPlatformLinuxAMD64InDocker); err != nil {
+	if err := txcrusttools.Ensure(ctx, txchaintools.Gaia, txcrusttools.TargetPlatformLinuxAMD64InDocker); err != nil {
 		return err
 	}
 
 	gaiaLocalPath := filepath.Join(
-		"bin", ".cache", gaiaBinaryName, crusttools.TargetPlatformLinuxAMD64InDocker.String(),
+		"bin", ".cache", gaiaBinaryName, txcrusttools.TargetPlatformLinuxAMD64InDocker.String(),
 	)
-	if err := crusttools.CopyToolBinaries(
+	if err := txcrusttools.CopyToolBinaries(
 		txchaintools.Gaia,
-		crusttools.TargetPlatformLinuxAMD64InDocker,
+		txcrusttools.TargetPlatformLinuxAMD64InDocker,
 		gaiaLocalPath,
 		gaiaBinaryPath,
 	); err != nil {
@@ -98,7 +98,7 @@ func BuildGaiaDockerImage(ctx context.Context, deps types.DepsFunc) error {
 	return docker.BuildImage(ctx, docker.BuildImageConfig{
 		ContextDir:      gaiaLocalPath,
 		ImageName:       gaiaBinaryName,
-		TargetPlatforms: []crusttools.TargetPlatform{crusttools.TargetPlatformLinuxAMD64InDocker},
+		TargetPlatforms: []txcrusttools.TargetPlatform{txcrusttools.TargetPlatformLinuxAMD64InDocker},
 		Dockerfile:      dockerfile,
 		Versions:        []string{config.ZNetVersion},
 	})
@@ -106,16 +106,16 @@ func BuildGaiaDockerImage(ctx context.Context, deps types.DepsFunc) error {
 
 // BuildHermesDockerImage builds docker image of the ibc relayer.
 func BuildHermesDockerImage(ctx context.Context, deps types.DepsFunc) error {
-	if err := crusttools.Ensure(ctx, txchaintools.Hermes, crusttools.TargetPlatformLinuxAMD64InDocker); err != nil {
+	if err := txcrusttools.Ensure(ctx, txchaintools.Hermes, txcrusttools.TargetPlatformLinuxAMD64InDocker); err != nil {
 		return err
 	}
 
 	hermesLocalPath := filepath.Join(
-		"bin", ".cache", hermesBinaryName, crusttools.TargetPlatformLinuxAMD64InDocker.String(),
+		"bin", ".cache", hermesBinaryName, txcrusttools.TargetPlatformLinuxAMD64InDocker.String(),
 	)
-	if err := crusttools.CopyToolBinaries(
+	if err := txcrusttools.CopyToolBinaries(
 		txchaintools.Hermes,
-		crusttools.TargetPlatformLinuxAMD64InDocker,
+		txcrusttools.TargetPlatformLinuxAMD64InDocker,
 		hermesLocalPath,
 		hermesBinaryPath,
 	); err != nil {
@@ -134,7 +134,7 @@ func BuildHermesDockerImage(ctx context.Context, deps types.DepsFunc) error {
 	return docker.BuildImage(ctx, docker.BuildImageConfig{
 		ContextDir:      hermesLocalPath,
 		ImageName:       hermesBinaryName,
-		TargetPlatforms: []crusttools.TargetPlatform{crusttools.TargetPlatformLinuxAMD64InDocker},
+		TargetPlatforms: []txcrusttools.TargetPlatform{txcrusttools.TargetPlatformLinuxAMD64InDocker},
 		Dockerfile:      dockerfile,
 		Versions:        []string{config.ZNetVersion},
 	})
@@ -142,16 +142,16 @@ func BuildHermesDockerImage(ctx context.Context, deps types.DepsFunc) error {
 
 // BuildOsmosisDockerImage builds docker image of the osmosis.
 func BuildOsmosisDockerImage(ctx context.Context, deps types.DepsFunc) error {
-	if err := crusttools.Ensure(ctx, txchaintools.Osmosis, crusttools.TargetPlatformLinuxLocalArchInDocker); err != nil {
+	if err := txcrusttools.Ensure(ctx, txchaintools.Osmosis, txcrusttools.TargetPlatformLinuxLocalArchInDocker); err != nil {
 		return err
 	}
 
 	binaryLocalPath := filepath.Join(
-		"bin", ".cache", osmosisBinaryName, crusttools.TargetPlatformLinuxLocalArchInDocker.String(),
+		"bin", ".cache", osmosisBinaryName, txcrusttools.TargetPlatformLinuxLocalArchInDocker.String(),
 	)
-	if err := crusttools.CopyToolBinaries(
+	if err := txcrusttools.CopyToolBinaries(
 		txchaintools.Osmosis,
-		crusttools.TargetPlatformLinuxLocalArchInDocker,
+		txcrusttools.TargetPlatformLinuxLocalArchInDocker,
 		binaryLocalPath,
 		osmosisBinaryPath,
 	); err != nil {
@@ -177,10 +177,10 @@ func BuildOsmosisDockerImage(ctx context.Context, deps types.DepsFunc) error {
 func buildTXdInDocker(
 	ctx context.Context,
 	deps types.DepsFunc,
-	targetPlatform crusttools.TargetPlatform,
+	targetPlatform txcrusttools.TargetPlatform,
 	extraFlags []string,
 ) error {
-	if err := crusttools.Ensure(ctx, txchaintools.LibWASM, targetPlatform); err != nil {
+	if err := txcrusttools.Ensure(ctx, txchaintools.LibWASM, targetPlatform); err != nil {
 		return err
 	}
 
@@ -190,9 +190,9 @@ func buildTXdInDocker(
 	envs := make([]string, 0)
 	dockerVolumes := make([]string, 0)
 	switch targetPlatform.OS {
-	case crusttools.OSLinux:
+	case txcrusttools.OSLinux:
 		// use cc not installed on the image we use for the build
-		if err := crusttools.Ensure(ctx, txchaintools.MuslCC, targetPlatform); err != nil {
+		if err := txcrusttools.Ensure(ctx, txchaintools.MuslCC, targetPlatform); err != nil {
 			return err
 		}
 		buildTags = append(buildTags, "muslc")
@@ -207,19 +207,19 @@ func buildTXdInDocker(
 			wasmCCLibRelativeLibPath string
 		)
 		switch targetPlatform {
-		case crusttools.TargetPlatformLinuxAMD64InDocker:
+		case txcrusttools.TargetPlatformLinuxAMD64InDocker:
 			hostCCDirPath = filepath.Dir(
-				filepath.Dir(crusttools.Path("bin/x86_64-linux-musl-gcc", targetPlatform)),
+				filepath.Dir(txcrusttools.Path("bin/x86_64-linux-musl-gcc", targetPlatform)),
 			)
 			ccRelativePath = "/bin/x86_64-linux-musl-gcc"
-			wasmHostDirPath = crusttools.Path("lib/libwasmvm_muslc.x86_64.a", targetPlatform)
+			wasmHostDirPath = txcrusttools.Path("lib/libwasmvm_muslc.x86_64.a", targetPlatform)
 			wasmCCLibRelativeLibPath = "/x86_64-linux-musl/lib/libwasmvm_muslc.x86_64.a"
-		case crusttools.TargetPlatformLinuxARM64InDocker:
+		case txcrusttools.TargetPlatformLinuxARM64InDocker:
 			hostCCDirPath = filepath.Dir(
-				filepath.Dir(crusttools.Path("bin/aarch64-linux-musl-gcc", targetPlatform)),
+				filepath.Dir(txcrusttools.Path("bin/aarch64-linux-musl-gcc", targetPlatform)),
 			)
 			ccRelativePath = "/bin/aarch64-linux-musl-gcc"
-			wasmHostDirPath = crusttools.Path("lib/libwasmvm_muslc.aarch64.a", targetPlatform)
+			wasmHostDirPath = txcrusttools.Path("lib/libwasmvm_muslc.aarch64.a", targetPlatform)
 			wasmCCLibRelativeLibPath = "/aarch64-linux-musl/lib/libwasmvm_muslc.aarch64.a"
 		default:
 			return errors.Errorf("building is not possible for platform %s", targetPlatform)
@@ -232,17 +232,17 @@ func buildTXdInDocker(
 			fmt.Sprintf("%s:%s", wasmHostDirPath, fmt.Sprintf("%s%s", ccDockerDir, wasmCCLibRelativeLibPath)),
 		)
 		cc = fmt.Sprintf("%s%s", ccDockerDir, ccRelativePath)
-	case crusttools.OSDarwin:
+	case txcrusttools.OSDarwin:
 		buildTags = append(buildTags, "static_wasm")
 		switch targetPlatform {
-		case crusttools.TargetPlatformDarwinAMD64InDocker:
+		case txcrusttools.TargetPlatformDarwinAMD64InDocker:
 			cc = "o64-clang"
-		case crusttools.TargetPlatformDarwinARM64InDocker:
+		case txcrusttools.TargetPlatformDarwinARM64InDocker:
 			cc = "oa64-clang"
 		default:
 			return errors.Errorf("building is not possible for platform %s", targetPlatform)
 		}
-		wasmHostDirPath := crusttools.Path("lib/libwasmvmstatic_darwin.a", targetPlatform)
+		wasmHostDirPath := txcrusttools.Path("lib/libwasmvmstatic_darwin.a", targetPlatform)
 		dockerVolumes = append(dockerVolumes, fmt.Sprintf("%s:%s", wasmHostDirPath, "/lib/libwasmvmstatic_darwin.a"))
 		envs = append(envs, "CGO_LDFLAGS=-L/lib")
 	default:
@@ -318,7 +318,7 @@ func txdVersionLDFlags(ctx context.Context, buildTags []string) ([]string, error
 func formatProto(ctx context.Context, deps types.DepsFunc) error {
 	deps(txchaintools.EnsureBuf)
 
-	cmd := exec.Command(crusttools.Path("bin/buf", crusttools.TargetPlatformLocal), "format", "-w")
+	cmd := exec.Command(txcrusttools.Path("bin/buf", txcrusttools.TargetPlatformLocal), "format", "-w")
 	cmd.Dir = filepath.Join(repoPath, "proto", "coreum")
 	return libexec.Exec(ctx, cmd)
 }

--- a/build/tx-chain/build.go
+++ b/build/tx-chain/build.go
@@ -142,7 +142,8 @@ func BuildHermesDockerImage(ctx context.Context, deps types.DepsFunc) error {
 
 // BuildOsmosisDockerImage builds docker image of the osmosis.
 func BuildOsmosisDockerImage(ctx context.Context, deps types.DepsFunc) error {
-	if err := txcrusttools.Ensure(ctx, txchaintools.Osmosis, txcrusttools.TargetPlatformLinuxLocalArchInDocker); err != nil {
+	if err := txcrusttools.Ensure(ctx,
+		txchaintools.Osmosis, txcrusttools.TargetPlatformLinuxLocalArchInDocker); err != nil {
 		return err
 	}
 

--- a/build/tx-chain/cosmovisor.go
+++ b/build/tx-chain/cosmovisor.go
@@ -4,18 +4,18 @@ import (
 	"context"
 	"path/filepath"
 
-	crusttools "github.com/tokenize-x/crust/build/tools"
 	txchaintools "github.com/tokenize-x/tx-chain/build/tools"
+	txcrusttools "github.com/tokenize-x/tx-crust/build/tools"
 )
 
 func ensureCosmovisorWithInstalledBinary(
-	ctx context.Context, platform crusttools.TargetPlatform, binaryName string,
+	ctx context.Context, platform txcrusttools.TargetPlatform, binaryName string,
 ) error {
-	if err := crusttools.Ensure(ctx, txchaintools.Cosmovisor, platform); err != nil {
+	if err := txcrusttools.Ensure(ctx, txchaintools.Cosmovisor, platform); err != nil {
 		return err
 	}
 
-	return crusttools.CopyToolBinaries(txchaintools.Cosmovisor,
+	return txcrusttools.CopyToolBinaries(txchaintools.Cosmovisor,
 		platform,
 		filepath.Join("bin", ".cache", binaryName, platform.String()),
 		cosmovisorBinaryPath)

--- a/build/tx-chain/generate-proto-breaking.go
+++ b/build/tx-chain/generate-proto-breaking.go
@@ -12,11 +12,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tokenize-x/crust/build/git"
-	"github.com/tokenize-x/crust/build/golang"
-	crusttools "github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
 	txchaintools "github.com/tokenize-x/tx-chain/build/tools"
+	"github.com/tokenize-x/tx-crust/build/git"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	txcrusttools "github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 	"github.com/tokenize-x/tx-tools/pkg/libexec"
 	"github.com/tokenize-x/tx-tools/pkg/must"
 )
@@ -35,7 +35,7 @@ func breakingProto(ctx context.Context, deps types.DepsFunc) error {
 	}
 	defer os.RemoveAll(masterDir) //nolint:errcheck // error doesn't matter
 
-	if err := git.CloneLocalBranch(ctx, masterDir, repoPath, "crust/proto-breaking", "master"); err != nil {
+	if err := git.CloneLocalBranch(ctx, masterDir, repoPath, "tx-crust/proto-breaking", "master"); err != nil {
 		return err
 	}
 	if err := golang.DownloadDependencies(ctx, deps, masterDir); err != nil {
@@ -63,7 +63,7 @@ func breakingProto(ctx context.Context, deps types.DepsFunc) error {
 		return errors.WithStack(err)
 	}
 
-	cmdImage := exec.Command(crusttools.Path("bin/protoc", crusttools.TargetPlatformLocal),
+	cmdImage := exec.Command(txcrusttools.Path("bin/protoc", txcrusttools.TargetPlatformLocal),
 		append(
 			append([]string{"--include_imports", "--include_source_info", "-o", imageFile}, masterIncludeArgs...),
 			masterProtoFiles...)...)
@@ -102,11 +102,11 @@ func breakingProto(ctx context.Context, deps types.DepsFunc) error {
 	args := []string{
 		"--buf-breaking_out=.",
 		fmt.Sprintf("--buf-breaking_opt=%s", configBuf),
-		"--plugin=" + crusttools.Path("bin/protoc-gen-buf-breaking", crusttools.TargetPlatformLocal),
+		"--plugin=" + txcrusttools.Path("bin/protoc-gen-buf-breaking", txcrusttools.TargetPlatformLocal),
 	}
 
 	args = append(args, includeArgs...)
 	args = append(args, masterProtoFiles...)
-	cmdBreaking := exec.Command(crusttools.Path("bin/protoc", crusttools.TargetPlatformLocal), args...)
+	cmdBreaking := exec.Command(txcrusttools.Path("bin/protoc", txcrusttools.TargetPlatformLocal), args...)
 	return libexec.Exec(ctx, cmdBreaking)
 }

--- a/build/tx-chain/generate-proto-docs.go
+++ b/build/tx-chain/generate-proto-docs.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tokenize-x/crust/build/golang"
-	crusttools "github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
 	txchaintools "github.com/tokenize-x/tx-chain/build/tools"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	txcrusttools "github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 	"github.com/tokenize-x/tx-tools/pkg/libexec"
 )
 
@@ -51,7 +51,7 @@ func executeProtocCommand(ctx context.Context, deps types.DepsFunc, includeDirs,
 
 	args := []string{
 		"--doc_out=docs",
-		"--plugin=" + crusttools.Path("bin/protoc-gen-doc", crusttools.TargetPlatformLocal),
+		"--plugin=" + txcrusttools.Path("bin/protoc-gen-doc", txcrusttools.TargetPlatformLocal),
 		"--doc_opt=docs/api.tmpl.md,api.md",
 	}
 
@@ -65,7 +65,7 @@ func executeProtocCommand(ctx context.Context, deps types.DepsFunc, includeDirs,
 	}
 	args = append(args, allProtoFiles...)
 
-	cmd := exec.Command(crusttools.Path("bin/protoc", crusttools.TargetPlatformLocal), args...)
+	cmd := exec.Command(txcrusttools.Path("bin/protoc", txcrusttools.TargetPlatformLocal), args...)
 	cmd.Dir = repoPath
 
 	return libexec.Exec(ctx, cmd)

--- a/build/tx-chain/generate-proto-go.go
+++ b/build/tx-chain/generate-proto-go.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tokenize-x/crust/build/golang"
-	crusttools "github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
 	txchaintools "github.com/tokenize-x/tx-chain/build/tools"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	txcrusttools "github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 	"github.com/tokenize-x/tx-tools/pkg/libexec"
 )
 
@@ -61,8 +61,8 @@ func executeGoProtocCommand(ctx context.Context, deps types.DepsFunc, includeDir
 	args := []string{
 		"--gocosmos_out=plugins=interfacetype+grpc,Mgoogle/protobuf/any.proto=github.com/cosmos/cosmos-sdk/codec/types:.",
 		"--grpc-gateway_out=logtostderr=true:.",
-		"--plugin=" + crusttools.Path("bin/protoc-gen-gocosmos", crusttools.TargetPlatformLocal),
-		"--plugin=" + crusttools.Path("bin/protoc-gen-grpc-gateway", crusttools.TargetPlatformLocal),
+		"--plugin=" + txcrusttools.Path("bin/protoc-gen-gocosmos", txcrusttools.TargetPlatformLocal),
+		"--plugin=" + txcrusttools.Path("bin/protoc-gen-grpc-gateway", txcrusttools.TargetPlatformLocal),
 	}
 
 	for _, path := range includeDirs {
@@ -85,7 +85,7 @@ func executeGoProtocCommand(ctx context.Context, deps types.DepsFunc, includeDir
 	for _, files := range packages {
 		args := append([]string{}, args...)
 		args = append(args, files...)
-		cmd := exec.Command(crusttools.Path("bin/protoc", crusttools.TargetPlatformLocal), args...)
+		cmd := exec.Command(txcrusttools.Path("bin/protoc", txcrusttools.TargetPlatformLocal), args...)
 		cmd.Dir = outDir
 		if err := libexec.Exec(ctx, cmd); err != nil {
 			return err

--- a/build/tx-chain/generate-proto-lint.go
+++ b/build/tx-chain/generate-proto-lint.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tokenize-x/crust/build/golang"
-	crusttools "github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
 	txchaintools "github.com/tokenize-x/tx-chain/build/tools"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	txcrusttools "github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 	"github.com/tokenize-x/tx-tools/pkg/libexec"
 )
 
@@ -52,7 +52,7 @@ func executeLintProtocCommand(ctx context.Context, deps types.DepsFunc, includeD
 	args := []string{
 		"--buf-lint_out=.",
 		fmt.Sprintf("--buf-lint_opt=%s", configLint),
-		"--plugin=" + crusttools.Path("bin/protoc-gen-buf-lint", crusttools.TargetPlatformLocal),
+		"--plugin=" + txcrusttools.Path("bin/protoc-gen-buf-lint", txcrusttools.TargetPlatformLocal),
 	}
 
 	for _, path := range includeDirs {
@@ -75,7 +75,7 @@ func executeLintProtocCommand(ctx context.Context, deps types.DepsFunc, includeD
 	for _, files := range packages {
 		args := append([]string{}, args...)
 		args = append(args, files...)
-		cmd := exec.Command(crusttools.Path("bin/protoc", crusttools.TargetPlatformLocal), args...)
+		cmd := exec.Command(txcrusttools.Path("bin/protoc", txcrusttools.TargetPlatformLocal), args...)
 		if err := libexec.Exec(ctx, cmd); err != nil {
 			return err
 		}

--- a/build/tx-chain/generate-proto-openapi.go
+++ b/build/tx-chain/generate-proto-openapi.go
@@ -12,10 +12,10 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/pkg/errors"
 
-	"github.com/tokenize-x/crust/build/golang"
-	crusttools "github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
 	txbuildtools "github.com/tokenize-x/tx-chain/build/tools"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	txcrusttools "github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 	"github.com/tokenize-x/tx-tools/pkg/libexec"
 )
 
@@ -98,7 +98,7 @@ func executeOpenAPIProtocCommand(ctx context.Context, deps types.DepsFunc, inclu
 
 	args := []string{
 		"--openapiv2_out=logtostderr=true,allow_merge=true,json_names_for_fields=false,fqn_for_openapi_name=true,simple_operation_ids=true,Mgoogle/protobuf/any.proto=github.com/cosmos/cosmos-sdk/codec/types:.", //nolint:lll // breaking down this string will make it more complicated.
-		"--plugin=" + crusttools.Path("bin/protoc-gen-openapiv2", crusttools.TargetPlatformLocal),
+		"--plugin=" + txcrusttools.Path("bin/protoc-gen-openapiv2", txcrusttools.TargetPlatformLocal),
 	}
 
 	for _, path := range includeDirs {
@@ -137,7 +137,7 @@ func executeOpenAPIProtocCommand(ctx context.Context, deps types.DepsFunc, inclu
 			}
 			args := append([]string{}, args...)
 			args = append(args, pf)
-			cmd := exec.Command(crusttools.Path("bin/protoc", crusttools.TargetPlatformLocal), args...)
+			cmd := exec.Command(txcrusttools.Path("bin/protoc", txcrusttools.TargetPlatformLocal), args...)
 			cmd.Dir = dir
 			if err := libexec.Exec(ctx, cmd); err != nil {
 				return err

--- a/build/tx-chain/generate.go
+++ b/build/tx-chain/generate.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tokenize-x/crust/build/golang"
-	"github.com/tokenize-x/crust/build/types"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	"github.com/tokenize-x/tx-crust/build/types"
 )
 
 const (

--- a/build/tx-chain/images.go
+++ b/build/tx-chain/images.go
@@ -5,18 +5,18 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/tokenize-x/crust/build/config"
-	"github.com/tokenize-x/crust/build/docker"
-	crusttools "github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
 	txchaintools "github.com/tokenize-x/tx-chain/build/tools"
 	"github.com/tokenize-x/tx-chain/build/tx-chain/image"
 	"github.com/tokenize-x/tx-chain/v6/pkg/config/constant"
+	"github.com/tokenize-x/tx-crust/build/config"
+	"github.com/tokenize-x/tx-crust/build/docker"
+	txcrusttools "github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 )
 
 type imageConfig struct {
 	BinaryPath      string
-	TargetPlatforms []crusttools.TargetPlatform
+	TargetPlatforms []txcrusttools.TargetPlatform
 	Action          docker.Action
 	Username        string
 	Versions        []string
@@ -28,7 +28,7 @@ func BuildTXdDockerImage(ctx context.Context, deps types.DepsFunc) error {
 
 	return buildTXdDockerImage(ctx, imageConfig{
 		BinaryPath:      binaryPath,
-		TargetPlatforms: []crusttools.TargetPlatform{crusttools.TargetPlatformLinuxLocalArchInDocker},
+		TargetPlatforms: []txcrusttools.TargetPlatform{txcrusttools.TargetPlatformLinuxLocalArchInDocker},
 		Action:          docker.ActionLoad,
 		Versions:        []string{config.ZNetVersion},
 	})
@@ -69,24 +69,24 @@ func buildTXdDockerImage(ctx context.Context, cfg imageConfig) error {
 // TODO (v7): Rename all cored to txd.
 func ensureReleasedBinaries(ctx context.Context, deps types.DepsFunc) error {
 	const binaryTool = txchaintools.CoredV500
-	if err := crusttools.Ensure(ctx, binaryTool, crusttools.TargetPlatformLinuxLocalArchInDocker); err != nil {
+	if err := txcrusttools.Ensure(ctx, binaryTool, txcrusttools.TargetPlatformLinuxLocalArchInDocker); err != nil {
 		return err
 	}
-	if err := crusttools.CopyToolBinaries(
+	if err := txcrusttools.CopyToolBinaries(
 		binaryTool,
-		crusttools.TargetPlatformLinuxLocalArchInDocker,
-		filepath.Join("bin", ".cache", binaryName, crusttools.TargetPlatformLinuxLocalArchInDocker.String()),
+		txcrusttools.TargetPlatformLinuxLocalArchInDocker,
+		filepath.Join("bin", ".cache", binaryName, txcrusttools.TargetPlatformLinuxLocalArchInDocker.String()),
 		fmt.Sprintf("bin/%s", binaryTool)); err != nil {
 		return err
 	}
 	// copy the release binary for the local platform to use for the genesis generation
-	if err := crusttools.Ensure(ctx, binaryTool, crusttools.TargetPlatformLocal); err != nil {
+	if err := txcrusttools.Ensure(ctx, binaryTool, txcrusttools.TargetPlatformLocal); err != nil {
 		return err
 	}
-	return crusttools.CopyToolBinaries(
+	return txcrusttools.CopyToolBinaries(
 		binaryTool,
-		crusttools.TargetPlatformLocal,
-		filepath.Join("bin", ".cache", binaryName, crusttools.TargetPlatformLocal.String()),
+		txcrusttools.TargetPlatformLocal,
+		filepath.Join("bin", ".cache", binaryName, txcrusttools.TargetPlatformLocal.String()),
 		fmt.Sprintf("bin/%s", binaryTool),
 	)
 }

--- a/build/tx-chain/release.go
+++ b/build/tx-chain/release.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tokenize-x/crust/build/config"
-	"github.com/tokenize-x/crust/build/docker"
-	"github.com/tokenize-x/crust/build/git"
-	"github.com/tokenize-x/crust/build/tools"
-	"github.com/tokenize-x/crust/build/types"
+	"github.com/tokenize-x/tx-crust/build/config"
+	"github.com/tokenize-x/tx-crust/build/docker"
+	"github.com/tokenize-x/tx-crust/build/git"
+	"github.com/tokenize-x/tx-crust/build/tools"
+	"github.com/tokenize-x/tx-crust/build/types"
 )
 
 // ReleaseTXd releases txd binary for amd64 and arm64 to be published inside the release.

--- a/build/tx-chain/tests.go
+++ b/build/tx-chain/tests.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/tokenize-x/crust/build/golang"
-	"github.com/tokenize-x/crust/build/types"
-	"github.com/tokenize-x/crust/znet/infra"
-	"github.com/tokenize-x/crust/znet/infra/apps"
-	"github.com/tokenize-x/crust/znet/infra/apps/txd"
-	"github.com/tokenize-x/crust/znet/pkg/znet"
 	"github.com/tokenize-x/tx-chain/v6/testutil/simapp"
+	"github.com/tokenize-x/tx-crust/build/golang"
+	"github.com/tokenize-x/tx-crust/build/types"
+	"github.com/tokenize-x/tx-crust/znet/infra"
+	"github.com/tokenize-x/tx-crust/znet/infra/apps"
+	"github.com/tokenize-x/tx-crust/znet/infra/apps/txd"
+	"github.com/tokenize-x/tx-crust/znet/pkg/znet"
 )
 
 // Test names.

--- a/build/tx-chain/wasm.go
+++ b/build/tx-chain/wasm.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/tokenize-x/crust/build/rust"
-	"github.com/tokenize-x/crust/build/types"
+	"github.com/tokenize-x/tx-crust/build/rust"
+	"github.com/tokenize-x/tx-crust/build/types"
 )
 
 // Smart contract names.

--- a/integration-tests/modules/gov_test.go
+++ b/integration-tests/modules/gov_test.go
@@ -158,7 +158,7 @@ func TestExpeditedGovProposalWithDepositAndWeightedVotes(t *testing.T) {
 	govParams, err := gov.QueryGovParams(ctx)
 	requireT.NoError(err)
 
-	// It is hardcoded from crust infra/apps/profiles.go and infra/apps/txd/config.go
+	// It is hardcoded from tx-crust infra/apps/profiles.go and infra/apps/txd/config.go
 	// remember to change these values if they are changed there
 	unexpectedParams := govParams.ExpeditedVotingPeriod != lo.ToPtr(15*time.Second) ||
 		len(govParams.ExpeditedMinDeposit) == 0 ||

--- a/x/deterministicgas/README.md
+++ b/x/deterministicgas/README.md
@@ -3,7 +3,7 @@
 After every upgrade of Cosmos SDK (or whenever we decide) we should verify that our deterministic gas estimations for messages are correct.
 
 To do it:
-1. Modify crust to deploy `explorer` and `monitoring` profiles when integration tests are started
+1. Modify tx-crust to deploy `explorer` and `monitoring` profiles when integration tests are started
 2. Run integration tests
 3. Go to our Grafana dashboard in `znet`
 4. Take values for deterministic gas factors reported there


### PR DESCRIPTION
# Description

This pull request updates the project to use the new `tx-crust` repository and package instead of the legacy `crust` repository. The changes affect documentation, build scripts, CI configuration, and code imports, ensuring consistency and compatibility with the renamed package.

Repository migration and codebase updates:

* All Go import paths and references have been updated from `github.com/tokenize-x/crust` to `github.com/tokenize-x/tx-crust` across multiple files, including `build/cmd/builder/main.go`, `build/cmd/znet/main.go`, `build/index.go`, `build/tools/tools.go`, and the various build scripts in `build/tx-chain/`. 
* All usages of the `crusttools` alias and related types/functions have been replaced with `txcrusttools` to match the new package structure and naming conventions. This includes changes to build targets, tool installation, and binary copying logic. 
* The Go module file `build/go.mod` has been updated to remove the old `crust` replacements and add the new `tx-crust` dependencies.

Documentation and configuration updates:

* References to `crust` in the documentation (`README.md`) and issue templates (`.github/ISSUE_TEMPLATE/bug-report.yaml`) have been updated to `tx-crust` for clarity and accuracy. 

General consistency improvements:

* Comments and inline documentation throughout the codebase have been updated to refer to `tx-crust` instead of `crust`, ensuring future maintainability and reducing confusion.

These changes ensure the project is fully migrated to the new `tx-crust` package and repository, reducing ambiguity and aligning all tooling and documentation with the new naming conventions.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.
