### PR TITLE
PSE Clearing accounts balances Query

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -285,6 +285,9 @@
     - [Params](#tx.pse.v1.Params)
   
 - [tx/pse/v1/query.proto](#tx/pse/v1/query.proto)
+    - [ClearingAccountBalance](#tx.pse.v1.ClearingAccountBalance)
+    - [QueryClearingAccountBalancesRequest](#tx.pse.v1.QueryClearingAccountBalancesRequest)
+    - [QueryClearingAccountBalancesResponse](#tx.pse.v1.QueryClearingAccountBalancesResponse)
     - [QueryParamsRequest](#tx.pse.v1.QueryParamsRequest)
     - [QueryParamsResponse](#tx.pse.v1.QueryParamsResponse)
     - [QueryScoreRequest](#tx.pse.v1.QueryScoreRequest)
@@ -5910,6 +5913,59 @@ Params store gov manageable parameters.
 
 
 
+<a name="tx.pse.v1.ClearingAccountBalance"></a>
+
+### ClearingAccountBalance
+
+```
+ClearingAccountBalance represents the balance of a single clearing account.
+```
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `clearing_account` | [string](#string) |  |  `clearing_account is the name of the clearing account.`  |
+| `balance` | [string](#string) |  |  `balance is the current balance of the clearing account in the bond denom.`  |
+
+
+
+
+
+
+<a name="tx.pse.v1.QueryClearingAccountBalancesRequest"></a>
+
+### QueryClearingAccountBalancesRequest
+
+```
+QueryClearingAccountBalancesRequest defines the request type for querying clearing account balances.
+```
+
+
+
+
+
+
+
+<a name="tx.pse.v1.QueryClearingAccountBalancesResponse"></a>
+
+### QueryClearingAccountBalancesResponse
+
+```
+QueryClearingAccountBalancesResponse defines the response type for querying clearing account balances.
+```
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `balances` | [ClearingAccountBalance](#tx.pse.v1.ClearingAccountBalance) | repeated |  `balances contains the current balances of all PSE clearing accounts in the bond denom.`  |
+
+
+
+
+
+
 <a name="tx.pse.v1.QueryParamsRequest"></a>
 
 ### QueryParamsRequest
@@ -6000,6 +6056,7 @@ Query defines the gRPC querier service.
 | ----------- | ------------ | ------------- | ------------| ------- | -------- |
 | `Params` | [QueryParamsRequest](#tx.pse.v1.QueryParamsRequest) | [QueryParamsResponse](#tx.pse.v1.QueryParamsResponse) | `Params queries the parameters of the module.` | GET|/tx/pse/v1/params |
 | `Score` | [QueryScoreRequest](#tx.pse.v1.QueryScoreRequest) | [QueryScoreResponse](#tx.pse.v1.QueryScoreResponse) | `Score queries the current total score of an account (delegator).` | GET|/tx/pse/v1/score/{address} |
+| `ClearingAccountBalances` | [QueryClearingAccountBalancesRequest](#tx.pse.v1.QueryClearingAccountBalancesRequest) | [QueryClearingAccountBalancesResponse](#tx.pse.v1.QueryClearingAccountBalancesResponse) | `ClearingAccountBalances queries the current balances of all PSE clearing accounts.` | GET|/tx/pse/v1/clearing_account_balances |
 
  <!-- end services -->
 

--- a/proto/tx/pse/v1/query.proto
+++ b/proto/tx/pse/v1/query.proto
@@ -4,6 +4,7 @@ package tx.pse.v1;
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 import "cosmos/query/v1/query.proto";
+import "cosmos_proto/cosmos.proto";
 import "tx/pse/v1/params.proto";
 
 option go_package = "github.com/tokenize-x/tx-chain/v6/x/pse/types";
@@ -21,6 +22,12 @@ service Query {
   rpc Score(QueryScoreRequest) returns (QueryScoreResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
     option (google.api.http).get = "/tx/pse/v1/score/{address}";
+  }
+  
+  // ClearingAccountBalances queries the current balances of all PSE clearing accounts.
+  rpc ClearingAccountBalances(QueryClearingAccountBalancesRequest) returns (QueryClearingAccountBalancesResponse) {
+    option (cosmos.query.v1.module_query_safe) = true;
+    option (google.api.http).get = "/tx/pse/v1/clearing_account_balances";
   }
 }
 
@@ -50,5 +57,33 @@ message QueryScoreResponse {
   string score = 1 [
     (gogoproto.customtype) = "cosmossdk.io/math.Int",
     (gogoproto.nullable) = false
+  ];
+}
+
+// QueryClearingAccountBalancesRequest defines the request type for querying clearing account balances.
+message QueryClearingAccountBalancesRequest {}
+
+// ClearingAccountBalance represents the balance of a single clearing account.
+message ClearingAccountBalance {
+  // clearing_account is the name of the clearing account.
+  string clearing_account = 1 [
+    (gogoproto.moretags) = "yaml:\"clearing_account\""
+  ];
+  
+  // balance is the current balance of the clearing account in the bond denom.
+  string balance = 2 [
+    (cosmos_proto.scalar) = "cosmos.Int",
+    (gogoproto.customtype) = "cosmossdk.io/math.Int",
+    (gogoproto.nullable) = false,
+    (gogoproto.moretags) = "yaml:\"balance\""
+  ];
+}
+
+// QueryClearingAccountBalancesResponse defines the response type for querying clearing account balances.
+message QueryClearingAccountBalancesResponse {
+  // balances contains the current balances of all PSE clearing accounts in the bond denom.
+  repeated ClearingAccountBalance balances = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.moretags) = "yaml:\"balances\""
   ];
 }

--- a/proto/tx/pse/v1/query.proto
+++ b/proto/tx/pse/v1/query.proto
@@ -23,7 +23,7 @@ service Query {
     option (cosmos.query.v1.module_query_safe) = true;
     option (google.api.http).get = "/tx/pse/v1/score/{address}";
   }
-  
+
   // ClearingAccountBalances queries the current balances of all PSE clearing accounts.
   rpc ClearingAccountBalances(QueryClearingAccountBalancesRequest) returns (QueryClearingAccountBalancesResponse) {
     option (cosmos.query.v1.module_query_safe) = true;
@@ -69,7 +69,7 @@ message ClearingAccountBalance {
   string clearing_account = 1 [
     (gogoproto.moretags) = "yaml:\"clearing_account\""
   ];
-  
+
   // balance is the current balance of the clearing account in the bond denom.
   string balance = 2 [
     (cosmos_proto.scalar) = "cosmos.Int",

--- a/x/pse/keeper/grpc.go
+++ b/x/pse/keeper/grpc.go
@@ -50,3 +50,18 @@ func (qs QueryService) Score(ctx context.Context, req *types.QueryScoreRequest) 
 		Score: score,
 	}, nil
 }
+
+// ClearingAccountBalances returns the current balances of all PSE clearing accounts.
+func (qs QueryService) ClearingAccountBalances(
+	ctx context.Context,
+	req *types.QueryClearingAccountBalancesRequest,
+) (*types.QueryClearingAccountBalancesResponse, error) {
+	balances, err := qs.keeper.GetClearingAccountBalances(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.QueryClearingAccountBalancesResponse{
+		Balances: balances,
+	}, nil
+}

--- a/x/pse/types/query.pb.go
+++ b/x/pse/types/query.pb.go
@@ -7,6 +7,7 @@ import (
 	context "context"
 	cosmossdk_io_math "cosmossdk.io/math"
 	fmt "fmt"
+	_ "github.com/cosmos/cosmos-proto"
 	_ "github.com/cosmos/cosmos-sdk/types/query"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/cosmos/gogoproto/grpc"
@@ -201,44 +202,188 @@ func (m *QueryScoreResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryScoreResponse proto.InternalMessageInfo
 
+// QueryClearingAccountBalancesRequest defines the request type for querying clearing account balances.
+type QueryClearingAccountBalancesRequest struct {
+}
+
+func (m *QueryClearingAccountBalancesRequest) Reset()         { *m = QueryClearingAccountBalancesRequest{} }
+func (m *QueryClearingAccountBalancesRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryClearingAccountBalancesRequest) ProtoMessage()    {}
+func (*QueryClearingAccountBalancesRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_1bf0a69d5178bfb9, []int{4}
+}
+func (m *QueryClearingAccountBalancesRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryClearingAccountBalancesRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryClearingAccountBalancesRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryClearingAccountBalancesRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryClearingAccountBalancesRequest.Merge(m, src)
+}
+func (m *QueryClearingAccountBalancesRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryClearingAccountBalancesRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryClearingAccountBalancesRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryClearingAccountBalancesRequest proto.InternalMessageInfo
+
+// ClearingAccountBalance represents the balance of a single clearing account.
+type ClearingAccountBalance struct {
+	// clearing_account is the name of the clearing account.
+	ClearingAccount string `protobuf:"bytes,1,opt,name=clearing_account,json=clearingAccount,proto3" json:"clearing_account,omitempty" yaml:"clearing_account"`
+	// balance is the current balance of the clearing account in the bond denom.
+	Balance cosmossdk_io_math.Int `protobuf:"bytes,2,opt,name=balance,proto3,customtype=cosmossdk.io/math.Int" json:"balance" yaml:"balance"`
+}
+
+func (m *ClearingAccountBalance) Reset()         { *m = ClearingAccountBalance{} }
+func (m *ClearingAccountBalance) String() string { return proto.CompactTextString(m) }
+func (*ClearingAccountBalance) ProtoMessage()    {}
+func (*ClearingAccountBalance) Descriptor() ([]byte, []int) {
+	return fileDescriptor_1bf0a69d5178bfb9, []int{5}
+}
+func (m *ClearingAccountBalance) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *ClearingAccountBalance) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_ClearingAccountBalance.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *ClearingAccountBalance) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ClearingAccountBalance.Merge(m, src)
+}
+func (m *ClearingAccountBalance) XXX_Size() int {
+	return m.Size()
+}
+func (m *ClearingAccountBalance) XXX_DiscardUnknown() {
+	xxx_messageInfo_ClearingAccountBalance.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ClearingAccountBalance proto.InternalMessageInfo
+
+func (m *ClearingAccountBalance) GetClearingAccount() string {
+	if m != nil {
+		return m.ClearingAccount
+	}
+	return ""
+}
+
+// QueryClearingAccountBalancesResponse defines the response type for querying clearing account balances.
+type QueryClearingAccountBalancesResponse struct {
+	// balances contains the current balances of all PSE clearing accounts in the bond denom.
+	Balances []ClearingAccountBalance `protobuf:"bytes,1,rep,name=balances,proto3" json:"balances" yaml:"balances"`
+}
+
+func (m *QueryClearingAccountBalancesResponse) Reset()         { *m = QueryClearingAccountBalancesResponse{} }
+func (m *QueryClearingAccountBalancesResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryClearingAccountBalancesResponse) ProtoMessage()    {}
+func (*QueryClearingAccountBalancesResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_1bf0a69d5178bfb9, []int{6}
+}
+func (m *QueryClearingAccountBalancesResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryClearingAccountBalancesResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryClearingAccountBalancesResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryClearingAccountBalancesResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryClearingAccountBalancesResponse.Merge(m, src)
+}
+func (m *QueryClearingAccountBalancesResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryClearingAccountBalancesResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryClearingAccountBalancesResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryClearingAccountBalancesResponse proto.InternalMessageInfo
+
+func (m *QueryClearingAccountBalancesResponse) GetBalances() []ClearingAccountBalance {
+	if m != nil {
+		return m.Balances
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*QueryParamsRequest)(nil), "tx.pse.v1.QueryParamsRequest")
 	proto.RegisterType((*QueryParamsResponse)(nil), "tx.pse.v1.QueryParamsResponse")
 	proto.RegisterType((*QueryScoreRequest)(nil), "tx.pse.v1.QueryScoreRequest")
 	proto.RegisterType((*QueryScoreResponse)(nil), "tx.pse.v1.QueryScoreResponse")
+	proto.RegisterType((*QueryClearingAccountBalancesRequest)(nil), "tx.pse.v1.QueryClearingAccountBalancesRequest")
+	proto.RegisterType((*ClearingAccountBalance)(nil), "tx.pse.v1.ClearingAccountBalance")
+	proto.RegisterType((*QueryClearingAccountBalancesResponse)(nil), "tx.pse.v1.QueryClearingAccountBalancesResponse")
 }
 
 func init() { proto.RegisterFile("tx/pse/v1/query.proto", fileDescriptor_1bf0a69d5178bfb9) }
 
 var fileDescriptor_1bf0a69d5178bfb9 = []byte{
-	// 417 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x92, 0x41, 0x8b, 0xda, 0x40,
-	0x14, 0xc7, 0x93, 0x82, 0x16, 0xa7, 0xf4, 0xe0, 0xa8, 0x45, 0x52, 0x1d, 0x4b, 0x2e, 0x2d, 0x85,
-	0xcc, 0xa0, 0x42, 0x0f, 0x3d, 0x15, 0x2f, 0xc5, 0x5b, 0x9b, 0x1e, 0x0a, 0xbd, 0x8d, 0x71, 0x88,
-	0x41, 0x93, 0x89, 0x99, 0x51, 0x62, 0x4b, 0x2f, 0x3d, 0xf5, 0xb8, 0xb0, 0x5f, 0x64, 0x3f, 0x86,
-	0x47, 0x61, 0x2f, 0xcb, 0x1e, 0xdc, 0x45, 0x17, 0xf6, 0xbe, 0x9f, 0x60, 0x49, 0x66, 0x76, 0x75,
-	0x5d, 0xbc, 0x25, 0xef, 0xfd, 0xdf, 0xff, 0xff, 0x7b, 0x8f, 0x01, 0x35, 0x99, 0x92, 0x58, 0x30,
-	0x32, 0x6f, 0x93, 0xe9, 0x8c, 0x25, 0x0b, 0x1c, 0x27, 0x5c, 0x72, 0x58, 0x92, 0x29, 0x8e, 0x05,
-	0xc3, 0xf3, 0xb6, 0x55, 0xf5, 0xb9, 0xcf, 0xf3, 0x2a, 0xc9, 0xbe, 0x94, 0xc0, 0x6a, 0xf8, 0x9c,
-	0xfb, 0x13, 0x46, 0x68, 0x1c, 0x10, 0x1a, 0x45, 0x5c, 0x52, 0x19, 0xf0, 0x48, 0xe8, 0xee, 0x5b,
-	0x8f, 0x8b, 0x90, 0x0b, 0x65, 0x79, 0xe0, 0x6d, 0xbd, 0xd9, 0x45, 0xc6, 0x34, 0xa1, 0xa1, 0x1e,
-	0xb2, 0xab, 0x00, 0x7e, 0xcf, 0x64, 0xdf, 0xf2, 0xa2, 0xcb, 0xa6, 0x33, 0x26, 0xa4, 0xfd, 0x13,
-	0x54, 0x9e, 0x54, 0x45, 0xcc, 0x23, 0xc1, 0xe0, 0x17, 0x50, 0x54, 0xc3, 0x75, 0xf3, 0x9d, 0xf9,
-	0xe1, 0x55, 0xa7, 0x8c, 0x1f, 0x89, 0xb1, 0x92, 0xf6, 0x6a, 0xcb, 0x75, 0xcb, 0xb8, 0x5b, 0xb7,
-	0x5e, 0x2f, 0x68, 0x38, 0xf9, 0x6c, 0x2b, 0xb9, 0xed, 0xea, 0x39, 0xdb, 0x01, 0xe5, 0xdc, 0xf8,
-	0x87, 0xc7, 0x13, 0xa6, 0xd3, 0x60, 0x1d, 0xbc, 0xa4, 0xc3, 0x61, 0xc2, 0x84, 0xf2, 0x2d, 0xb9,
-	0x0f, 0xbf, 0x76, 0x5f, 0xd3, 0x69, 0xb9, 0xc6, 0xe8, 0x82, 0x82, 0xc8, 0x0a, 0x4a, 0xdd, 0x6b,
-	0x66, 0x91, 0x97, 0xeb, 0x56, 0x4d, 0xed, 0x2f, 0x86, 0x63, 0x1c, 0x70, 0x12, 0x52, 0x39, 0xc2,
-	0xfd, 0x48, 0xba, 0x4a, 0xdb, 0xb9, 0x32, 0x41, 0x21, 0xf7, 0x82, 0x3e, 0x28, 0x2a, 0x58, 0xd8,
-	0xdc, 0xe3, 0x7f, 0x7e, 0x05, 0x0b, 0x1d, 0x6b, 0x2b, 0x0e, 0x1b, 0xfd, 0xbf, 0x3d, 0xfb, 0x68,
-	0xfe, 0x3b, 0xbf, 0x39, 0x7d, 0x51, 0x81, 0x65, 0x72, 0x78, 0x61, 0x18, 0x82, 0x42, 0x0e, 0x0e,
-	0x1b, 0x87, 0x46, 0xfb, 0xeb, 0x5b, 0xcd, 0x23, 0x5d, 0x9d, 0xf2, 0x7e, 0x97, 0xd2, 0x80, 0xd6,
-	0x5e, 0x4a, 0xbe, 0x17, 0xf9, 0xa3, 0x6f, 0xf5, 0xb7, 0xf7, 0x75, 0xb9, 0x41, 0xe6, 0x6a, 0x83,
-	0xcc, 0xeb, 0x0d, 0x32, 0x4f, 0xb6, 0xc8, 0x58, 0x6d, 0x91, 0x71, 0xb1, 0x45, 0xc6, 0x2f, 0xc7,
-	0x0f, 0xe4, 0x68, 0x36, 0xc0, 0x1e, 0x0f, 0x89, 0xe4, 0x63, 0x16, 0x05, 0xbf, 0x99, 0x93, 0x12,
-	0x99, 0x3a, 0xde, 0x88, 0x06, 0x11, 0x99, 0x7f, 0x22, 0xca, 0x55, 0x2e, 0x62, 0x26, 0x06, 0xc5,
-	0xfc, 0x69, 0x74, 0xef, 0x03, 0x00, 0x00, 0xff, 0xff, 0xf5, 0x31, 0x85, 0x01, 0xa7, 0x02, 0x00,
-	0x00,
+	// 590 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x54, 0xcf, 0x6b, 0x13, 0x41,
+	0x14, 0xce, 0xb6, 0xb4, 0xb5, 0x53, 0xb4, 0x76, 0xfa, 0x23, 0x71, 0x9b, 0x6c, 0x74, 0xac, 0x5a,
+	0x84, 0xec, 0x90, 0x14, 0x3c, 0x08, 0x82, 0x46, 0x50, 0x7a, 0xd3, 0x15, 0x2c, 0x78, 0x09, 0x93,
+	0xcd, 0xb0, 0x59, 0x9a, 0xdd, 0xd9, 0xee, 0x4c, 0x42, 0xa2, 0xe8, 0xc1, 0x93, 0x37, 0x05, 0xff,
+	0x0e, 0xc1, 0x83, 0x17, 0xff, 0x83, 0x1e, 0x8b, 0x5e, 0xc4, 0x43, 0x90, 0x44, 0xf0, 0x9e, 0xbf,
+	0x40, 0x76, 0x67, 0xf2, 0x6b, 0x6d, 0x82, 0xb7, 0xec, 0x7b, 0xdf, 0xfb, 0xde, 0xf7, 0xcd, 0xfb,
+	0x08, 0xd8, 0x16, 0x6d, 0x1c, 0x70, 0x8a, 0x5b, 0x45, 0x7c, 0xd2, 0xa4, 0x61, 0xc7, 0x0c, 0x42,
+	0x26, 0x18, 0x5c, 0x15, 0x6d, 0x33, 0xe0, 0xd4, 0x6c, 0x15, 0xf5, 0x2d, 0x87, 0x39, 0x2c, 0xae,
+	0xe2, 0xe8, 0x97, 0x04, 0xe8, 0x59, 0x87, 0x31, 0xa7, 0x41, 0x31, 0x09, 0x5c, 0x4c, 0x7c, 0x9f,
+	0x09, 0x22, 0x5c, 0xe6, 0x73, 0xd5, 0xdd, 0xb5, 0x19, 0xf7, 0x18, 0x97, 0x94, 0x09, 0x6e, 0xfd,
+	0x8a, 0x6c, 0x56, 0x24, 0xa7, 0xfc, 0x50, 0xad, 0x9d, 0xb1, 0x9a, 0x80, 0x84, 0xc4, 0x53, 0x75,
+	0xb4, 0x05, 0xe0, 0xd3, 0x88, 0xe1, 0x49, 0x5c, 0xb4, 0xe8, 0x49, 0x93, 0x72, 0x81, 0x8e, 0xc0,
+	0xe6, 0x54, 0x95, 0x07, 0xcc, 0xe7, 0x14, 0xde, 0x07, 0xcb, 0x72, 0x38, 0xa3, 0x5d, 0xd5, 0xf6,
+	0xd7, 0x4a, 0x1b, 0xe6, 0xc8, 0x8c, 0x29, 0xa1, 0xe5, 0xed, 0xd3, 0x6e, 0x3e, 0x35, 0xe8, 0xe6,
+	0x2f, 0x76, 0x88, 0xd7, 0xb8, 0x8b, 0x24, 0x1c, 0x59, 0x6a, 0x0e, 0x15, 0xc0, 0x46, 0x4c, 0xfc,
+	0xcc, 0x66, 0x21, 0x55, 0xdb, 0x60, 0x06, 0xac, 0x90, 0x5a, 0x2d, 0xa4, 0x5c, 0xf2, 0xae, 0x5a,
+	0xc3, 0x4f, 0x74, 0xa8, 0xd4, 0x29, 0xb8, 0x92, 0x71, 0x00, 0x96, 0x78, 0x54, 0x90, 0xe8, 0x72,
+	0x2e, 0x5a, 0xf9, 0xb3, 0x9b, 0xdf, 0x96, 0x86, 0x79, 0xed, 0xd8, 0x74, 0x19, 0xf6, 0x88, 0xa8,
+	0x9b, 0x87, 0xbe, 0xb0, 0x24, 0x16, 0xdd, 0x00, 0xd7, 0x63, 0xaa, 0x87, 0x0d, 0x4a, 0x42, 0xd7,
+	0x77, 0x1e, 0xd8, 0x36, 0x6b, 0xfa, 0xa2, 0x4c, 0x1a, 0xc4, 0xb7, 0xe9, 0xc8, 0xf9, 0x57, 0x0d,
+	0xec, 0x9c, 0x0f, 0x81, 0x8f, 0xc0, 0x65, 0x5b, 0x75, 0x2a, 0x44, 0xb6, 0x94, 0x82, 0xdd, 0x41,
+	0x37, 0x9f, 0x96, 0x86, 0x93, 0x08, 0x64, 0xad, 0xdb, 0xd3, 0x74, 0xf0, 0x08, 0xac, 0x54, 0x25,
+	0x65, 0x66, 0x21, 0x1e, 0xbf, 0x37, 0xd7, 0xc0, 0xa0, 0x9b, 0xbf, 0x24, 0xb9, 0xd5, 0x14, 0xfa,
+	0xf6, 0xa5, 0x00, 0xd4, 0x71, 0x23, 0x83, 0x43, 0x36, 0xf4, 0x06, 0xec, 0xcd, 0xb7, 0xa8, 0xde,
+	0xef, 0x39, 0xb8, 0xa0, 0x46, 0xa2, 0x07, 0x5f, 0xdc, 0x5f, 0x2b, 0x5d, 0x9b, 0x38, 0xe4, 0xf9,
+	0xd3, 0xe5, 0xb4, 0x3a, 0xec, 0xfa, 0x94, 0x16, 0x8e, 0xac, 0x11, 0x57, 0xe9, 0xfd, 0x22, 0x58,
+	0x8a, 0x05, 0x40, 0x07, 0x2c, 0xcb, 0x3c, 0xc0, 0xdc, 0x04, 0xf3, 0xbf, 0x41, 0xd3, 0x8d, 0x59,
+	0x6d, 0x29, 0x15, 0x19, 0xef, 0xfe, 0x7c, 0xbe, 0xad, 0xbd, 0xfd, 0xfe, 0xfb, 0xe3, 0xc2, 0x26,
+	0xdc, 0xc0, 0xc9, 0x10, 0x43, 0x0f, 0x2c, 0xc5, 0xd9, 0x80, 0xd9, 0x24, 0xd1, 0x64, 0xc2, 0xf4,
+	0xdc, 0x8c, 0xae, 0xda, 0x72, 0x6b, 0xbc, 0x25, 0x0b, 0xf5, 0x89, 0x2d, 0x71, 0x74, 0xf0, 0x2b,
+	0x15, 0xc7, 0xd7, 0xf0, 0x93, 0x06, 0xd2, 0x33, 0x5e, 0x17, 0x9a, 0xc9, 0x1d, 0xf3, 0x93, 0xa6,
+	0xe3, 0xff, 0xc6, 0x2b, 0x95, 0xc5, 0xb1, 0xca, 0x9b, 0x70, 0x6f, 0x42, 0x65, 0x32, 0x73, 0x95,
+	0xe1, 0x45, 0xca, 0x8f, 0x4f, 0x7b, 0x86, 0x76, 0xd6, 0x33, 0xb4, 0x5f, 0x3d, 0x43, 0xfb, 0xd0,
+	0x37, 0x52, 0x67, 0x7d, 0x23, 0xf5, 0xa3, 0x6f, 0xa4, 0x5e, 0x14, 0x1c, 0x57, 0xd4, 0x9b, 0x55,
+	0xd3, 0x66, 0x1e, 0x16, 0xec, 0x98, 0xfa, 0xee, 0x4b, 0x5a, 0x68, 0x63, 0xd1, 0x2e, 0xd8, 0x75,
+	0xe2, 0xfa, 0xb8, 0x75, 0x07, 0x4b, 0x7e, 0xd1, 0x09, 0x28, 0xaf, 0x2e, 0xc7, 0xff, 0x16, 0x07,
+	0x7f, 0x03, 0x00, 0x00, 0xff, 0xff, 0x72, 0x88, 0x08, 0x8b, 0xd5, 0x04, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -257,6 +402,8 @@ type QueryClient interface {
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
 	// Score queries the current total score of an account (delegator).
 	Score(ctx context.Context, in *QueryScoreRequest, opts ...grpc.CallOption) (*QueryScoreResponse, error)
+	// ClearingAccountBalances queries the current balances of all PSE clearing accounts.
+	ClearingAccountBalances(ctx context.Context, in *QueryClearingAccountBalancesRequest, opts ...grpc.CallOption) (*QueryClearingAccountBalancesResponse, error)
 }
 
 type queryClient struct {
@@ -285,12 +432,23 @@ func (c *queryClient) Score(ctx context.Context, in *QueryScoreRequest, opts ...
 	return out, nil
 }
 
+func (c *queryClient) ClearingAccountBalances(ctx context.Context, in *QueryClearingAccountBalancesRequest, opts ...grpc.CallOption) (*QueryClearingAccountBalancesResponse, error) {
+	out := new(QueryClearingAccountBalancesResponse)
+	err := c.cc.Invoke(ctx, "/tx.pse.v1.Query/ClearingAccountBalances", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // QueryServer is the server API for Query service.
 type QueryServer interface {
 	// Params queries the parameters of the module.
 	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)
 	// Score queries the current total score of an account (delegator).
 	Score(context.Context, *QueryScoreRequest) (*QueryScoreResponse, error)
+	// ClearingAccountBalances queries the current balances of all PSE clearing accounts.
+	ClearingAccountBalances(context.Context, *QueryClearingAccountBalancesRequest) (*QueryClearingAccountBalancesResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -302,6 +460,9 @@ func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsReq
 }
 func (*UnimplementedQueryServer) Score(ctx context.Context, req *QueryScoreRequest) (*QueryScoreResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Score not implemented")
+}
+func (*UnimplementedQueryServer) ClearingAccountBalances(ctx context.Context, req *QueryClearingAccountBalancesRequest) (*QueryClearingAccountBalancesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ClearingAccountBalances not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -344,6 +505,24 @@ func _Query_Score_Handler(srv interface{}, ctx context.Context, dec func(interfa
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_ClearingAccountBalances_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryClearingAccountBalancesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).ClearingAccountBalances(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/tx.pse.v1.Query/ClearingAccountBalances",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).ClearingAccountBalances(ctx, req.(*QueryClearingAccountBalancesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _Query_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "tx.pse.v1.Query",
 	HandlerType: (*QueryServer)(nil),
@@ -355,6 +534,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Score",
 			Handler:    _Query_Score_Handler,
+		},
+		{
+			MethodName: "ClearingAccountBalances",
+			Handler:    _Query_ClearingAccountBalances_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -480,6 +663,106 @@ func (m *QueryScoreResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryClearingAccountBalancesRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryClearingAccountBalancesRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryClearingAccountBalancesRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *ClearingAccountBalance) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ClearingAccountBalance) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ClearingAccountBalance) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size := m.Balance.Size()
+		i -= size
+		if _, err := m.Balance.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x12
+	if len(m.ClearingAccount) > 0 {
+		i -= len(m.ClearingAccount)
+		copy(dAtA[i:], m.ClearingAccount)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.ClearingAccount)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryClearingAccountBalancesResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryClearingAccountBalancesResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryClearingAccountBalancesResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Balances) > 0 {
+		for iNdEx := len(m.Balances) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Balances[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintQuery(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintQuery(dAtA []byte, offset int, v uint64) int {
 	offset -= sovQuery(v)
 	base := offset
@@ -532,6 +815,45 @@ func (m *QueryScoreResponse) Size() (n int) {
 	_ = l
 	l = m.Score.Size()
 	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryClearingAccountBalancesRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *ClearingAccountBalance) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.ClearingAccount)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	l = m.Balance.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryClearingAccountBalancesResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Balances) > 0 {
+		for _, e := range m.Balances {
+			l = e.Size()
+			n += 1 + l + sovQuery(uint64(l))
+		}
+	}
 	return n
 }
 
@@ -816,6 +1138,256 @@ func (m *QueryScoreResponse) Unmarshal(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			if err := m.Score.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryClearingAccountBalancesRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryClearingAccountBalancesRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryClearingAccountBalancesRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *ClearingAccountBalance) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ClearingAccountBalance: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ClearingAccountBalance: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClearingAccount", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClearingAccount = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Balance", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Balance.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryClearingAccountBalancesResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryClearingAccountBalancesResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryClearingAccountBalancesResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Balances", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Balances = append(m.Balances, ClearingAccountBalance{})
+			if err := m.Balances[len(m.Balances)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/pse/types/query.pb.gw.go
+++ b/x/pse/types/query.pb.gw.go
@@ -105,6 +105,24 @@ func local_request_Query_Score_0(ctx context.Context, marshaler runtime.Marshale
 
 }
 
+func request_Query_ClearingAccountBalances_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryClearingAccountBalancesRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := client.ClearingAccountBalances(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_ClearingAccountBalances_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryClearingAccountBalancesRequest
+	var metadata runtime.ServerMetadata
+
+	msg, err := server.ClearingAccountBalances(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterQueryHandlerServer registers the http handlers for service Query to "mux".
 // UnaryRPC     :call QueryServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -154,6 +172,29 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 		}
 
 		forward_Query_Score_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Query_ClearingAccountBalances_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_ClearingAccountBalances_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ClearingAccountBalances_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -238,6 +279,26 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_ClearingAccountBalances_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_ClearingAccountBalances_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ClearingAccountBalances_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -245,10 +306,14 @@ var (
 	pattern_Query_Params_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"tx", "pse", "v1", "params"}, "", runtime.AssumeColonVerbOpt(true)))
 
 	pattern_Query_Score_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"tx", "pse", "v1", "score", "address"}, "", runtime.AssumeColonVerbOpt(true)))
+
+	pattern_Query_ClearingAccountBalances_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"tx", "pse", "v1", "clearing_account_balances"}, "", runtime.AssumeColonVerbOpt(true)))
 )
 
 var (
 	forward_Query_Params_0 = runtime.ForwardResponseMessage
 
 	forward_Query_Score_0 = runtime.ForwardResponseMessage
+
+	forward_Query_ClearingAccountBalances_0 = runtime.ForwardResponseMessage
 )


### PR DESCRIPTION
# Description

This pull request introduces a new gRPC query endpoint to retrieve the current balances of all PSE clearing accounts. The changes span the API documentation, protobuf definitions, keeper logic, gRPC service implementation, and test coverage. The most important changes are grouped below:

**API and Protobuf Enhancements:**

* Added new message types (`ClearingAccountBalance`, `QueryClearingAccountBalancesRequest`, and `QueryClearingAccountBalancesResponse`) and documented them in both `proto/tx/pse/v1/query.proto` and `docs/api.md`, enabling structured querying of clearing account balances. 
* Registered a new gRPC query method `ClearingAccountBalances` in the `Query` service, including REST endpoint mapping (`GET /tx/pse/v1/clearing_account_balances`) and updated documentation. 

**Keeper and Query Logic:**

* Implemented `GetClearingAccountBalances` in `x/pse/keeper/keeper.go` to fetch balances for all clearing accounts in the bond denom, handling missing accounts and zero balances gracefully.
* Added the corresponding gRPC service handler in `x/pse/keeper/grpc.go` to expose this functionality via the new query endpoint.

**Testing and Gateway Updates:**

* Added comprehensive tests in `x/pse/keeper/grpc_query_test.go` to verify the new query returns correct balances for all clearing accounts, both when balances are zero and when some are funded.
* Updated the gRPC gateway code in `x/pse/types/query.pb.gw.go` to support HTTP requests for the new endpoint, including handler registration and response forwarding. 

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/29)
<!-- Reviewable:end -->
