### PR TITLE
Rmove the version from upgrade CI title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
             "integration tests tx-chain-modules",
             "integration tests tx-chain-stress",
             "integration tests tx-chain-ibc",
-            "integration tests tx-chain-upgrade-v5.0.3",
+            "integration tests tx-chain-upgrade",
           ]
         include:
           - ci_step: "lint"
@@ -60,7 +60,7 @@ jobs:
             linter-cache: false
             wasm-cache: true
             codecov: false
-          - ci_step: "integration tests tx-chain-upgrade-v5.0.3"
+          - ci_step: "integration tests tx-chain-upgrade"
             command: make integration-tests-upgrade
             linter-cache: false
             wasm-cache: true


### PR DESCRIPTION
# Description

This pull request makes a minor update to the CI workflow configuration by generalizing the name of the upgrade integration test step. This change helps keep the workflow up-to-date and avoids hardcoding specific version numbers, and changing the GitHub Settings.

- Workflow configuration:
  * Updated the `ci_step` name from `"integration tests tx-chain-upgrade-v5.0.3"` to the more generic `"integration tests tx-chain-upgrade"` in `.github/workflows/ci.yml`. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL28-R28) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL63-R63)

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/65)
<!-- Reviewable:end -->
