### PR TITLE
fix: OS keyring migration from cored to txd

### DIFF
--- a/cmd/txd/main.go
+++ b/cmd/txd/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
+	"github.com/cosmos/cosmos-sdk/version"
 
 	"github.com/tokenize-x/tx-chain/v6/app"
 	"github.com/tokenize-x/tx-chain/v6/cmd/txd/cosmoscmd"
@@ -14,6 +15,9 @@ import (
 const txChainEnvPrefix = "TXD"
 
 func main() {
+	// OS keyring backend uses version.Name as namespace label; must match cored's.
+	version.Name = "coreum"
+
 	network, err := cosmoscmd.PreProcessFlags()
 	if err != nil {
 		fmt.Printf("Error processing chain id flag, err: %s", err)


### PR DESCRIPTION
Resolves: https://app.clickup.com/t/868hcma36
# Description
OS keyring backend uses `version.Name` as namespace. Without override, `txd` defaults to `tx-chain` (or `cosmos` when built locally), mismatching `cored's` `coreum` - making os keys invisible across binaries.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/80)
<!-- Reviewable:end -->
