### PR TITLE
Implement CLI for migrating OS keyring keys

### DIFF
--- a/cmd/txd/cosmoscmd/migrate_keyring.go
+++ b/cmd/txd/cosmoscmd/migrate_keyring.go
@@ -1,0 +1,101 @@
+package cosmoscmd
+
+import (
+	"fmt"
+
+	"github.com/99designs/keyring"
+	sdkversion "github.com/cosmos/cosmos-sdk/version"
+	"github.com/spf13/cobra"
+)
+
+// Legacy OS keyring service names from previous binary versions.
+var legacyServiceNames = []string{"coreum"}
+
+// MigrateKeyringCmd migrates OS keyring keys from legacy service namespaces into the current one.
+func MigrateKeyringCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "migrate-keyring",
+		Short: "Migrate OS keyring keys from coreum namespace into tx-chain",
+		Long: `Copies OS keyring keys from "coreum" Keychain service into "tx-chain".
+Only affects the "os" keyring backend.`,
+		Args: cobra.NoArgs,
+		RunE: runMigrateKeyring,
+	}
+	return cmd
+}
+
+func openOSKeyring(serviceName string) (keyring.Keyring, error) {
+	return keyring.Open(keyring.Config{
+		ServiceName:              serviceName,
+		KeychainTrustApplication: true,
+		FilePasswordFunc:         func(_ string) (string, error) { return "", nil },
+	})
+}
+
+func runMigrateKeyring(cmd *cobra.Command, _ []string) error {
+	targetName := sdkversion.Name // "tx-chain"
+
+	destKr, err := openOSKeyring(targetName)
+	if err != nil {
+		return fmt.Errorf("failed to open destination keyring %q: %w", targetName, err)
+	}
+
+	totalMigrated := 0
+
+	for _, srcName := range legacyServiceNames {
+		if srcName == targetName {
+			continue
+		}
+
+		srcKr, err := openOSKeyring(srcName)
+		if err != nil {
+			cmd.PrintErrf("Warning: could not open keyring %q: %v\n", srcName, err)
+			continue
+		}
+
+		keys, err := srcKr.Keys()
+		if err != nil {
+			cmd.PrintErrf("Warning: could not list keys from %q: %v\n", srcName, err)
+			continue
+		}
+
+		if len(keys) == 0 {
+			cmd.Printf("No keys found in %q namespace.\n", srcName)
+			continue
+		}
+
+		migrated := 0
+		for _, key := range keys {
+			if _, err := destKr.Get(key); err == nil {
+				cmd.Printf("  Skipping %q (already exists in %q)\n", key, targetName)
+				continue
+			}
+
+			item, err := srcKr.Get(key)
+			if err != nil {
+				cmd.PrintErrf("  Warning: could not read %q from %q: %v\n", key, srcName, err)
+				continue
+			}
+
+			if err := destKr.Set(item); err != nil {
+				cmd.PrintErrf("  Warning: could not write %q to %q: %v\n", key, targetName, err)
+				continue
+			}
+
+			migrated++
+		}
+
+		if migrated > 0 {
+			cmd.Printf("Migrated %d key(s) from %q to %q.\n", migrated, srcName, targetName)
+		}
+		totalMigrated += migrated
+	}
+
+	if totalMigrated == 0 {
+		cmd.Println("No keys needed migration.")
+	} else {
+		cmd.Printf("Total: %d key(s) migrated to %q.\n", totalMigrated, targetName)
+	}
+
+	return nil
+}

--- a/cmd/txd/cosmoscmd/migrate_keyring.go
+++ b/cmd/txd/cosmoscmd/migrate_keyring.go
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Legacy OS keyring service names from previous binary versions.
-var legacyServiceNames = []string{"coreum"}
+// legacyServiceName is the OS keyring service name used by cored.
+const legacyServiceName = "coreum"
 
 // MigrateKeyringCmd migrates OS keyring keys from legacy service namespaces into the current one.
 func MigrateKeyringCmd() *cobra.Command {
@@ -35,66 +35,56 @@ func openOSKeyring(serviceName string) (keyring.Keyring, error) {
 func runMigrateKeyring(cmd *cobra.Command, _ []string) error {
 	targetName := sdkversion.Name // "tx-chain"
 
+	if legacyServiceName == targetName {
+		cmd.Println("Source and destination namespaces are the same, nothing to migrate.")
+		return nil
+	}
+
+	srcKr, err := openOSKeyring(legacyServiceName)
+	if err != nil {
+		return fmt.Errorf("failed to open source keyring %q: %w", legacyServiceName, err)
+	}
+
 	destKr, err := openOSKeyring(targetName)
 	if err != nil {
 		return fmt.Errorf("failed to open destination keyring %q: %w", targetName, err)
 	}
 
-	totalMigrated := 0
-
-	for _, srcName := range legacyServiceNames {
-		if srcName == targetName {
-			continue
-		}
-
-		srcKr, err := openOSKeyring(srcName)
-		if err != nil {
-			cmd.PrintErrf("Warning: could not open keyring %q: %v\n", srcName, err)
-			continue
-		}
-
-		keys, err := srcKr.Keys()
-		if err != nil {
-			cmd.PrintErrf("Warning: could not list keys from %q: %v\n", srcName, err)
-			continue
-		}
-
-		if len(keys) == 0 {
-			cmd.Printf("No keys found in %q namespace.\n", srcName)
-			continue
-		}
-
-		migrated := 0
-		for _, key := range keys {
-			if _, err := destKr.Get(key); err == nil {
-				cmd.Printf("  Skipping %q (already exists in %q)\n", key, targetName)
-				continue
-			}
-
-			item, err := srcKr.Get(key)
-			if err != nil {
-				cmd.PrintErrf("  Warning: could not read %q from %q: %v\n", key, srcName, err)
-				continue
-			}
-
-			if err := destKr.Set(item); err != nil {
-				cmd.PrintErrf("  Warning: could not write %q to %q: %v\n", key, targetName, err)
-				continue
-			}
-
-			migrated++
-		}
-
-		if migrated > 0 {
-			cmd.Printf("Migrated %d key(s) from %q to %q.\n", migrated, srcName, targetName)
-		}
-		totalMigrated += migrated
+	keys, err := srcKr.Keys()
+	if err != nil {
+		return fmt.Errorf("failed to list keys from %q: %w", legacyServiceName, err)
 	}
 
-	if totalMigrated == 0 {
+	if len(keys) == 0 {
+		cmd.Printf("No keys found in %q namespace.\n", legacyServiceName)
+		return nil
+	}
+
+	migrated := 0
+	for _, key := range keys {
+		if _, err := destKr.Get(key); err == nil {
+			cmd.Printf("  Skipping %q (already exists in %q)\n", key, targetName)
+			continue
+		}
+
+		item, err := srcKr.Get(key)
+		if err != nil {
+			cmd.PrintErrf("  Warning: could not read %q from %q: %v\n", key, legacyServiceName, err)
+			continue
+		}
+
+		if err := destKr.Set(item); err != nil {
+			cmd.PrintErrf("  Warning: could not write %q to %q: %v\n", key, targetName, err)
+			continue
+		}
+
+		migrated++
+	}
+
+	if migrated == 0 {
 		cmd.Println("No keys needed migration.")
 	} else {
-		cmd.Printf("Total: %d key(s) migrated to %q.\n", totalMigrated, targetName)
+		cmd.Printf("Migrated %d key(s) from %q to %q.\n", migrated, legacyServiceName, targetName)
 	}
 
 	return nil

--- a/cmd/txd/cosmoscmd/root.go
+++ b/cmd/txd/cosmoscmd/root.go
@@ -231,12 +231,14 @@ func initRootCmd(
 	server.AddCommands(rootCmd, app.DefaultNodeHome, newApp, appExport, addModuleInitFlags)
 
 	// add keybase, auxiliary RPC, query, genesis, and tx child commands
+	keysCmd := keys.Commands()
+	keysCmd.AddCommand(MigrateKeyringCmd())
 	rootCmd.AddCommand(
 		server.StatusCommand(),
 		genesisCommand(encodingConfig.TxConfig, basicManager),
 		queryCommand(),
 		txCommand(),
-		keys.Commands(),
+		keysCmd,
 	)
 
 	// add rosetta

--- a/cmd/txd/main.go
+++ b/cmd/txd/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
+	"github.com/cosmos/cosmos-sdk/version"
 
 	"github.com/tokenize-x/tx-chain/v6/app"
 	"github.com/tokenize-x/tx-chain/v6/cmd/txd/cosmoscmd"
@@ -14,6 +15,9 @@ import (
 const txChainEnvPrefix = "TXD"
 
 func main() {
+	// OS keyring backend uses version.Name as namespace label.
+	version.Name = "tx-chain"
+
 	network, err := cosmoscmd.PreProcessFlags()
 	if err != nil {
 		fmt.Printf("Error processing chain id flag, err: %s", err)

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	cosmossdk.io/x/nft v0.1.1
 	cosmossdk.io/x/tx v0.14.0
 	cosmossdk.io/x/upgrade v0.2.0
+	github.com/99designs/keyring v1.2.2
 	github.com/CosmWasm/wasmd v0.60.2
 	github.com/CosmWasm/wasmvm/v2 v2.2.4
 	github.com/cometbft/cometbft v0.38.21
@@ -87,7 +88,6 @@ require (
 	cosmossdk.io/schema v1.1.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
-	github.com/99designs/keyring v1.2.2 // indirect
 	github.com/DataDog/datadog-go v4.8.3+incompatible // indirect
 	github.com/DataDog/zstd v1.5.7 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect


### PR DESCRIPTION
# Description
OS keyring backend uses `version.Name` as keychain namespace. `cored` uses "coreum", `txd` uses "tx-chain" - keys are invisible across binaries. 
Adds `txd keys migrate-keyring` to **copy** keys from `coreum` into `tx-chain` namespace.

**Usage:** `txd keys migrate-keyring`

**Note:** _Keys are copied, not moved. Original keys remain in the source namespace for safety._

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/81)
<!-- Reviewable:end -->
