### PR TITLE
Fix Missed Lint Issues

### DIFF
--- a/build/go.mod
+++ b/build/go.mod
@@ -32,9 +32,9 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/samber/lo v1.49.1
-	github.com/tokenize-x/tx-chain/v7 v7.0.0-20260212090447-388e1cf45a9c
-	github.com/tokenize-x/tx-crust v0.0.0-20260217094652-0b8a52c0d45c
-	github.com/tokenize-x/tx-crust/znet v0.0.0-20260217094652-0b8a52c0d45c
+	github.com/tokenize-x/tx-chain/v7 v7.0.0-20260217111039-9296d325fd38
+	github.com/tokenize-x/tx-crust v0.0.0-20260223095532-73eae35f9722
+	github.com/tokenize-x/tx-crust/znet v0.0.0-20260223095532-73eae35f9722
 	github.com/tokenize-x/tx-tools v0.0.0-20251006151522-f6df01ec2033
 )
 

--- a/build/go.sum
+++ b/build/go.sum
@@ -1646,10 +1646,10 @@ github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e/go.mod h1:
 github.com/tidwall/btree v1.7.0 h1:L1fkJH/AuEh5zBnnBbmTwQ5Lt+bRJ5A8EWecslvo9iI=
 github.com/tidwall/btree v1.7.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tokenize-x/tx-crust v0.0.0-20260217094652-0b8a52c0d45c h1:QgDhFmCAwpwc1NKKyEPG1if89o9VfPPNGTiP0KY5WF4=
-github.com/tokenize-x/tx-crust v0.0.0-20260217094652-0b8a52c0d45c/go.mod h1:uBS4jcaHdXgfZTGYdpGm00EvHtramk3+W1g0EF6WI3E=
-github.com/tokenize-x/tx-crust/znet v0.0.0-20260217094652-0b8a52c0d45c h1:fQfAcv1DOxPp5qKJf9KKe33RsJIxIc9cc++O6/EFerc=
-github.com/tokenize-x/tx-crust/znet v0.0.0-20260217094652-0b8a52c0d45c/go.mod h1:7lknv301Up5Ez8sDRhWeHKcg4gXSX4+Ozm4/798lwjA=
+github.com/tokenize-x/tx-crust v0.0.0-20260223095532-73eae35f9722 h1:4HbCx+SpZ2fVXBkZyw8w8jJR7WRX1g89NCWeG9Etaws=
+github.com/tokenize-x/tx-crust v0.0.0-20260223095532-73eae35f9722/go.mod h1:uBS4jcaHdXgfZTGYdpGm00EvHtramk3+W1g0EF6WI3E=
+github.com/tokenize-x/tx-crust/znet v0.0.0-20260223095532-73eae35f9722 h1:0DynqWpwuVvDHbuHeuyuPhFH7rLMN+Xmu2v7KyKs7zM=
+github.com/tokenize-x/tx-crust/znet v0.0.0-20260223095532-73eae35f9722/go.mod h1:LJuHXCcsW3yiR0m1LI9DYfWfXYoxlNZAZ040uYXCEYE=
 github.com/tokenize-x/tx-tools v0.0.0-20251006151522-f6df01ec2033 h1:1++kosP83GjVa85RkTBxkzI3qNKPWp0uIRn4UiFQuPY=
 github.com/tokenize-x/tx-tools v0.0.0-20251006151522-f6df01ec2033/go.mod h1:tnc0L7WkOv6kah53Wl17fcG8G2MCPGotP1v2ezB/a/g=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=

--- a/build/tx-chain/build.go
+++ b/build/tx-chain/build.go
@@ -336,7 +336,7 @@ func Lint(ctx context.Context, deps types.DepsFunc) error {
 		CompileAllSmartContracts,
 		formatProto,
 		lintProto,
-		// breakingProto, TODO(Restore breaking proto)
+		breakingProto,
 	)
 	return lint.Lint(ctx, deps)
 }

--- a/build/tx-chain/generate-proto-breaking.go
+++ b/build/tx-chain/generate-proto-breaking.go
@@ -22,7 +22,7 @@ import (
 )
 
 //go:embed proto-breaking.tmpl.json
-var configBreakingTmpl string
+var configBreakingTmpl string //nolint:unused // used by template
 
 func breakingProto(ctx context.Context, deps types.DepsFunc) error {
 	deps(golang.Tidy, txchaintools.EnsureProtoc, txchaintools.EnsureProtocGenBufBreaking)

--- a/build/tx-chain/images.go
+++ b/build/tx-chain/images.go
@@ -29,11 +29,8 @@ type imageConfig struct {
 func BuildTXdDockerImage(ctx context.Context, deps types.DepsFunc) error {
 	deps(BuildTXdInDocker, ensureReleasedBinaries)
 
-	useLocalBinary := false
 	// skip building TXd in docker for Linux builds to avoid using the large GoReleaser when unnecessary
-	if runtime.GOOS == txcrusttools.OSLinux {
-		useLocalBinary = true
-	}
+	useLocalBinary := runtime.GOOS == txcrusttools.OSLinux
 
 	return buildTXdDockerImage(ctx, imageConfig{
 		BinaryPath:      binaryPath,

--- a/go.work.sum
+++ b/go.work.sum
@@ -1374,8 +1374,6 @@ github.com/cosmos/iavl v1.1.2/go.mod h1:jLeUvm6bGT1YutCaL2fIar/8vGUE8cPZvh/gXEWD
 github.com/cosmos/iavl v1.2.0/go.mod h1:HidWWLVAtODJqFD6Hbne2Y0q3SdxByJepHUOeoH4LiI=
 github.com/cosmos/iavl v1.2.2/go.mod h1:GiM43q0pB+uG53mLxLDzimxM9l/5N9UuSY3/D0huuVw=
 github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v8 v8.1.1/go.mod h1:8sbOclBgOCgBPesufd3ZlLRHvJ3dOeN9+dXhn3KbKOc=
-github.com/cosmos/ibc-apps/modules/ibc-hooks/v10 v10.0.0-20250919123430-5596e0a03585 h1:d4gGXTPMosllOyyj+kNSCJiN/UTBnjdvbPynlNTvRJg=
-github.com/cosmos/ibc-apps/modules/ibc-hooks/v10 v10.0.0-20250919123430-5596e0a03585/go.mod h1:YQmJRjlqccu5hFwnPeY4xcOQoJ2SEuMQGD1u32jREc0=
 github.com/cosmos/ibc-go/modules/apps/callbacks v0.2.1-0.20231113120333-342c00b0f8bd h1:Lx+/5dZ/nN6qPXP2Ofog6u1fmlkCFA1ElcOconnofEM=
 github.com/cosmos/ibc-go/modules/apps/callbacks v0.2.1-0.20231113120333-342c00b0f8bd/go.mod h1:JWfpWVKJKiKtd53/KbRoKfxWl8FsT2GPcNezTOk0o5Q=
 github.com/cosmos/ibc-go/modules/capability v1.0.0/go.mod h1:D81ZxzjZAe0ZO5ambnvn1qedsFQ8lOwtqicG6liLBco=
@@ -2920,10 +2918,14 @@ github.com/tokenize-x/tx-crust v0.0.0-20251204091714-85b536a4d6a0 h1:VA/UBUJ1MkY
 github.com/tokenize-x/tx-crust v0.0.0-20251204091714-85b536a4d6a0/go.mod h1:uBS4jcaHdXgfZTGYdpGm00EvHtramk3+W1g0EF6WI3E=
 github.com/tokenize-x/tx-crust v0.0.0-20260210121155-7b32c8260237 h1:LfBAQVVMSqP6M0hsGTAvzpJQpzhLqo5yWBhGafotEPM=
 github.com/tokenize-x/tx-crust v0.0.0-20260210121155-7b32c8260237/go.mod h1:uBS4jcaHdXgfZTGYdpGm00EvHtramk3+W1g0EF6WI3E=
+github.com/tokenize-x/tx-crust v0.0.0-20260223095532-73eae35f9722 h1:4HbCx+SpZ2fVXBkZyw8w8jJR7WRX1g89NCWeG9Etaws=
+github.com/tokenize-x/tx-crust v0.0.0-20260223095532-73eae35f9722/go.mod h1:uBS4jcaHdXgfZTGYdpGm00EvHtramk3+W1g0EF6WI3E=
 github.com/tokenize-x/tx-crust/znet v0.0.0-20251204091714-85b536a4d6a0 h1:CkcEu9z6bWu+bjuaURFalnI0X2SpWnvvSNODtlSQd2I=
 github.com/tokenize-x/tx-crust/znet v0.0.0-20251204091714-85b536a4d6a0/go.mod h1:328EyqltI5jgYWvbvVsZjlzjZ1Fm/EGSS7xEm0TpSdw=
 github.com/tokenize-x/tx-crust/znet v0.0.0-20260210121155-7b32c8260237 h1:e9flocsMtTCWHNE4wsCTFqrEqU8WSKT0HlW5nPboKBQ=
 github.com/tokenize-x/tx-crust/znet v0.0.0-20260210121155-7b32c8260237/go.mod h1:93TCCNLv8U5QxOQfflfj2BWGzILfvsjsfE9O1DXk+dE=
+github.com/tokenize-x/tx-crust/znet v0.0.0-20260223095532-73eae35f9722 h1:0DynqWpwuVvDHbuHeuyuPhFH7rLMN+Xmu2v7KyKs7zM=
+github.com/tokenize-x/tx-crust/znet v0.0.0-20260223095532-73eae35f9722/go.mod h1:LJuHXCcsW3yiR0m1LI9DYfWfXYoxlNZAZ040uYXCEYE=
 github.com/tomarrell/wrapcheck/v2 v2.8.1 h1:HxSqDSN0sAt0yJYsrcYVoEeyM4aI9yAm3KQpIXDJRhQ=
 github.com/tomarrell/wrapcheck/v2 v2.8.1/go.mod h1:/n2Q3NZ4XFT50ho6Hbxg+RV1uyo2Uow/Vdm9NQcl5SE=
 github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+yU8u1Zw=

--- a/integration-tests/ibc/ibc_v2_test.go
+++ b/integration-tests/ibc/ibc_v2_test.go
@@ -73,22 +73,22 @@ func TestIBCV2TransferTxToGaia(t *testing.T) {
 	// and MsgRecvPacket.
 	txRelayer := txChain.GenAccount()
 	gaiaRelayer := gaiaChain.GenAccount()
-	fundRelayers(t, ctx, txChain, gaiaChain, txRelayer, gaiaRelayer)
+	fundRelayers(ctx, t, txChain, gaiaChain, txRelayer, gaiaRelayer)
 
 	// IBC v2 client setup (replaces legacy connection + channel handshake)
 	// Each chain creates a Tendermint light client that tracks the other chain's consensus.
 	// Then we register the counterparty: this tells IBC Core how to route packets between
 	// this client and the other chain's client (Merkle path to the provable store).
-	txClientID := createTendermintClient(t, ctx, txChain.Chain, gaiaChain, txRelayer)
-	gaiaClientID := createTendermintClient(t, ctx, gaiaChain, txChain.Chain, gaiaRelayer)
-	registerCounterparty(t, ctx, txChain.Chain, txRelayer, txClientID, gaiaClientID)
-	registerCounterparty(t, ctx, gaiaChain, gaiaRelayer, gaiaClientID, txClientID)
+	txClientID := createTendermintClient(ctx, t, txChain.Chain, gaiaChain, txRelayer)
+	gaiaClientID := createTendermintClient(ctx, t, gaiaChain, txChain.Chain, gaiaRelayer)
+	registerCounterparty(ctx, t, txChain.Chain, txRelayer, txClientID, gaiaClientID)
+	registerCounterparty(ctx, t, gaiaChain, gaiaRelayer, gaiaClientID, txClientID)
 
 	// Sender and recipient; fund sender
 	sender := txChain.GenAccount()
 	recipient := gaiaChain.GenAccount()
 	amount := txChain.NewCoin(sdkmath.NewInt(transferAmount))
-	fundSenderForTransfer(t, ctx, txChain, sender)
+	fundSenderForTransfer(ctx, t, txChain, sender)
 
 	// Build and send v2 packet
 	// V2 uses MsgSendPacket with source client ID (not channel). The payload is a wrapped
@@ -110,23 +110,23 @@ func TestIBCV2TransferTxToGaia(t *testing.T) {
 		sendMsg,
 	)
 	require.NoError(t, err)
-	require.Greater(t, txResp.Height, int64(0), "tx height must be set for proof query")
+	require.Positive(t, txResp.Height, "tx height must be set for proof query")
 	t.Logf("v2 transfer sent, tx hash: %s", txResp.TxHash)
 
 	// Obtain packet commitment proof
 	// The commitment was written at txResp.Height. We query that height with Prove=true to get
 	// a merkle proof. The destination chain will verify this proof against its light client's
 	// consensus state at proofHeight (height+1 per ibc-go convention).
-	sequence := nextSequenceSend(t, ctx, txChain.Chain, txClientID) - 1
-	proofBz, proofHeight := packetCommitmentProof(t, ctx, txChain.Chain, txClientID, sequence, txResp.Height)
+	sequence := nextSequenceSend(ctx, t, txChain.Chain, txClientID) - 1
+	proofBz, proofHeight := packetCommitmentProof(ctx, t, txChain.Chain, txClientID, sequence, txResp.Height)
 
 	// Sync light client on Gaia and relay packet
 	// Gaia's client must have a consensus state at proofHeight before it can verify the proof.
 	// We wait until the source chain has committed that block, then submit a header update
 	// so the client stores the root at proofHeight. Then MsgRecvPacket verifies the proof
 	// against that root and executes the transfer.
-	waitForHeight(t, ctx, txChain.Chain, int64(proofHeight.GetRevisionHeight()))
-	updateTendermintClient(t, ctx, gaiaChain, txChain.Chain, gaiaRelayer, gaiaClientID, proofHeight)
+	waitForHeight(ctx, t, txChain.Chain, int64(proofHeight.GetRevisionHeight()))
+	updateTendermintClient(ctx, t, gaiaChain, txChain.Chain, gaiaRelayer, gaiaClientID, proofHeight)
 
 	packet := channeltypesv2.Packet{
 		Sequence:          sequence,
@@ -161,7 +161,10 @@ func TestIBCV2TransferTxToGaia(t *testing.T) {
 }
 
 // fundRelayers credits both relayer accounts so they can pay for client creation and packet relay.
-func fundRelayers(t *testing.T, ctx context.Context, txChain integration.TXChain, gaiaChain integration.Chain, txRelayer, gaiaRelayer sdk.AccAddress) {
+func fundRelayers(
+	ctx context.Context, t *testing.T, txChain integration.TXChain, gaiaChain integration.Chain,
+	txRelayer, gaiaRelayer sdk.AccAddress,
+) {
 	t.Helper()
 	txChain.Faucet.FundAccounts(ctx, t, integration.FundedAccount{
 		Address: txRelayer,
@@ -174,7 +177,7 @@ func fundRelayers(t *testing.T, ctx context.Context, txChain integration.TXChain
 }
 
 // fundSenderForTransfer funds the sender and registers MsgTransfer for gas estimation.
-func fundSenderForTransfer(t *testing.T, ctx context.Context, txChain integration.TXChain, sender sdk.AccAddress) {
+func fundSenderForTransfer(ctx context.Context, t *testing.T, txChain integration.TXChain, sender sdk.AccAddress) {
 	t.Helper()
 	txChain.FundAccountWithOptions(ctx, t, sender, integration.BalancesOptions{
 		Messages: []sdk.Msg{&ibctransfertypes.MsgTransfer{}},
@@ -217,20 +220,21 @@ func expectedIBCDenoms(baseDenom, sourceClientID, destClientID string) []string 
 // It uses the counterparty's latest header and staking params (unbonding/trusting period).
 // Returns the new client ID (e.g. "07-tendermint-1").
 func createTendermintClient(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	chain integration.Chain,
 	counterparty integration.Chain,
 	signer sdk.AccAddress,
 ) string {
 	t.Helper()
 
-	before := listClientIDs(t, ctx, chain)
+	before := listClientIDs(ctx, t, chain)
 	header, err := counterparty.LatestBlockHeader(ctx)
 	require.NoError(t, err)
 
 	// Trusting period must be less than unbonding period so the client can detect misbehaviour.
-	stakingResp, err := stakingtypes.NewQueryClient(counterparty.ClientContext).Params(ctx, &stakingtypes.QueryParamsRequest{})
+	stakingClient := stakingtypes.NewQueryClient(counterparty.ClientContext)
+	stakingResp, err := stakingClient.Params(ctx, &stakingtypes.QueryParamsRequest{})
 	require.NoError(t, err)
 	unbonding := stakingResp.Params.UnbondingTime
 	trusting := unbonding / 2
@@ -258,7 +262,7 @@ func createTendermintClient(
 	_, err = chain.BroadcastTxWithSigner(ctx, chain.TxFactory().WithGas(createClientGasLimit), signer, msg)
 	require.NoError(t, err)
 
-	after := listClientIDs(t, ctx, chain)
+	after := listClientIDs(ctx, t, chain)
 	clientID := findNewClientID(before, after)
 	require.NotEmpty(t, clientID, "client id not found after creation")
 	return clientID
@@ -268,8 +272,8 @@ func createTendermintClient(
 // This creates the association needed for IBC Core to route and verify packets. The Merkle
 // path tells the verifier where the provable store lives (Cosmos SDK: "ibc" store).
 func registerCounterparty(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	chain integration.Chain,
 	signer sdk.AccAddress,
 	clientID, counterpartyClientID string,
@@ -286,7 +290,7 @@ func registerCounterparty(
 }
 
 // listClientIDs returns all IBC client IDs on the chain (e.g. 07-tendermint-0, 07-tendermint-1).
-func listClientIDs(t *testing.T, ctx context.Context, chain integration.Chain) []string {
+func listClientIDs(ctx context.Context, t *testing.T, chain integration.Chain) []string {
 	t.Helper()
 	res, err := clienttypes.NewQueryClient(chain.ClientContext).ClientStates(ctx, &clienttypes.QueryClientStatesRequest{
 		Pagination: &query.PageRequest{Limit: query.PaginationMaxLimit},
@@ -317,8 +321,8 @@ func findNewClientID(before, after []string) string {
 // on clientChain to targetHeight. The client can then verify merkle proofs against the
 // consensus state at that height (used before relaying a packet).
 func updateTendermintClient(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	clientChain integration.Chain, // chain that stores the client state
 	counterpartyChain integration.Chain, // chain we fetch the header from
 	signer sdk.AccAddress,
@@ -327,7 +331,8 @@ func updateTendermintClient(
 ) {
 	t.Helper()
 
-	csRes, err := clienttypes.NewQueryClient(clientChain.ClientContext).ClientState(ctx, &clienttypes.QueryClientStateRequest{ClientId: clientID})
+	csClient := clienttypes.NewQueryClient(clientChain.ClientContext)
+	csRes, err := csClient.ClientState(ctx, &clienttypes.QueryClientStateRequest{ClientId: clientID})
 	require.NoError(t, err)
 	var clientState ibctmtypes.ClientState
 	require.Equal(t, "/ibc.lightclients.tendermint.v1.ClientState", csRes.ClientState.TypeUrl)
@@ -341,7 +346,7 @@ func updateTendermintClient(
 	commitRes, err := counterpartyChain.ClientContext.RPCClient().Commit(ctx, &height)
 	require.NoError(t, err)
 	require.NotNil(t, commitRes.SignedHeader)
-	signedHeaderProto := commitRes.SignedHeader.ToProto()
+	signedHeaderProto := commitRes.ToProto()
 
 	valsRes, err := counterpartyChain.ClientContext.RPCClient().Validators(ctx, &height, nil, nil)
 	require.NoError(t, err)
@@ -361,7 +366,7 @@ func updateTendermintClient(
 		TrustedValidators: trustedValSetProto,
 	}
 	// Tendermint header must match the validator set we fetched.
-	require.True(t, bytes.Equal(header.SignedHeader.Header.ValidatorsHash, valSet.Hash()), "validator hash mismatch")
+	require.True(t, bytes.Equal(header.Header.ValidatorsHash, valSet.Hash()), "validator hash mismatch")
 
 	anyHeader, err := codectypes.NewAnyWithValue(header)
 	require.NoError(t, err)
@@ -378,7 +383,7 @@ func updateTendermintClient(
 
 // nextSequenceSend returns the next sequence number to be used for sending on the given client.
 // After a send, the used sequence is nextSequenceSend - 1.
-func nextSequenceSend(t *testing.T, ctx context.Context, chain integration.Chain, clientID string) uint64 {
+func nextSequenceSend(ctx context.Context, t *testing.T, chain integration.Chain, clientID string) uint64 {
 	t.Helper()
 	res, err := channeltypesv2.NewQueryClient(chain.ClientContext).NextSequenceSend(
 		ctx, channeltypesv2.NewQueryNextSequenceSendRequest(clientID),
@@ -392,8 +397,8 @@ func nextSequenceSend(t *testing.T, ctx context.Context, chain integration.Chain
 // The destination chain verifies the proof against its light client's consensus state at
 // proofHeight. ibc-go expects proofHeight = commitmentBlockHeight + 1.
 func packetCommitmentProof(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	chain integration.Chain,
 	clientID string,
 	sequence uint64,
@@ -418,7 +423,7 @@ func packetCommitmentProof(
 	// IBC verifier expects proofHeight to be the height of the block that contains the commitment.
 	// Query at commitmentBlockHeight returns state at end of that block; reporting height+1 matches ibc-go.
 	revision := clienttypes.ParseChainID(chain.ChainSettings.ChainID)
-	proofHeight = clienttypes.NewHeight(uint64(revision), uint64(commitmentBlockHeight+1))
+	proofHeight = clienttypes.NewHeight(revision, uint64(commitmentBlockHeight+1))
 	return proofBz, proofHeight
 }
 
@@ -447,7 +452,10 @@ func buildTransferPayload(t *testing.T, msg *ibctransfertypes.MsgTransfer) chann
 
 // awaitIBCDenom waits until addr has an IBC denom balance equal to amount, then returns that denom.
 // It asserts the denom is one of expectedDenoms (v2 can mint with source or dest client ID in the path).
-func awaitIBCDenom(ctx context.Context, t *testing.T, chain integration.Chain, addr sdk.AccAddress, amount sdkmath.Int, expectedDenoms []string) string {
+func awaitIBCDenom(
+	ctx context.Context, t *testing.T, chain integration.Chain, addr sdk.AccAddress,
+	amount sdkmath.Int, expectedDenoms []string,
+) string {
 	t.Helper()
 
 	var denom string
@@ -475,7 +483,7 @@ func awaitIBCDenom(ctx context.Context, t *testing.T, chain integration.Chain, a
 
 // waitForHeight blocks until the chain's latest block height is at least targetHeight.
 // Used to ensure the commitment block is committed before we update the light client.
-func waitForHeight(t *testing.T, ctx context.Context, chain integration.Chain, targetHeight int64) {
+func waitForHeight(ctx context.Context, t *testing.T, chain integration.Chain, targetHeight int64) {
 	t.Helper()
 	require.NoError(t, chain.AwaitState(ctx, func(checkCtx context.Context) error {
 		status, err := chain.ClientContext.RPCClient().Status(checkCtx)

--- a/integration-tests/modules/pse_test.go
+++ b/integration-tests/modules/pse_test.go
@@ -338,7 +338,7 @@ func TestPSEDistribution(t *testing.T) {
 
 	scheduledDistributions, err = getScheduledDistribution(ctx, chain)
 	requireT.NoError(err)
-	requireT.Len(scheduledDistributions, 0)
+	requireT.Empty(scheduledDistributions)
 
 	balancesBefore, scoresBefore, totalScore = getAllDelegatorInfo(ctx, t, chain, height-1)
 	balancesAfter, _, _ = getAllDelegatorInfo(ctx, t, chain, height)
@@ -390,7 +390,7 @@ func TestPSEDistribution(t *testing.T) {
 		DelegatorAddr: excludedDelegator,
 	})
 	requireT.NoError(err)
-	requireT.Len(delRespAfter.DelegationResponses, 0, "Should have zero delegations after full undelegation")
+	requireT.Empty(delRespAfter.DelegationResponses, "Should have zero delegations after full undelegation")
 
 	t.Logf("Re-included delegator successfully undelegated full amount (%s)", currentDelegation.String())
 }


### PR DESCRIPTION
# Description

This pull request includes several improvements and updates across the codebase, focusing on dependency updates, test cleanup, and minor bug fixes. The most significant changes are grouped below by theme.

**Dependency and Build Updates:**

* Updated `github.com/tokenize-x/tx-chain/v7`, `github.com/tokenize-x/tx-crust`, and `github.com/tokenize-x/tx-crust/znet` dependencies in `build/go.mod` and `go.work.sum` to the latest versions, ensuring the project the fixes for linting for repos with more than one go modules. [[1]](diffhunk://#diff-244a6b40e7980a81294bf122768105e17d530d8108d13ac6ecc3b5e452a4e200L35-R37) [[2]](diffhunk://#diff-20cee3a725d1c5d2c595ff5372e6593d3bcaa7aebd8319866f65e90c6924f247R2921-R2928)
* Re-enabled the `breakingProto` lint check in `build/tx-chain/build.go` and clarified the usage of the embedded template in `build/tx-chain/generate-proto-breaking.go`. [[1]](diffhunk://#diff-6cec9771d62da92da0f8094695c8a15c671c4c596afc626c38dfefd1000d13fcL339-R339) [[2]](diffhunk://#diff-2fbb06bb5aa9cf7bc220a0e291f8ad7cb64cf91af6ac5b75cfd662e9274b7c94L25-R25)
* Simplified logic for determining when to use a local binary in Docker builds in `build/tx-chain/images.go`.

**Integration Test Improvements and Fixes:**

* Refactored integration test helper function signatures in `integration-tests/ibc/ibc_v2_test.go` to consistently use `(ctx context.Context, t *testing.T, ...)` ordering, improving readability and aligning with Go best practices. [[1]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL76-R91) [[2]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL164-R167) [[3]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL177-R180) [[4]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL220-R237) [[5]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL261-R265) [[6]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL271-R276) [[7]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL289-R293) [[8]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL320-R325) [[9]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL330-R335) [[10]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL344-R349) [[11]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL364-R369) [[12]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL381-R386) [[13]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL395-R401) [[14]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL421-R426) [[15]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL450-R458) [[16]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL478-R486)
* Fixed minor bugs in IBC v2 test logic, including correct use of `require.Positive` instead of `require.Greater` for height checks, correct assignment of proof heights, and improved usage of gRPC clients. [[1]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL113-R129) [[2]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL421-R426) [[3]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL344-R349) [[4]](diffhunk://#diff-3297e3a9c8a8c1b5f5199e7dc63346f675e972eddd87003f72d259ba4273eaceL364-R369)

**Test Assertion Cleanup:**

* Replaced deprecated or less clear assertions with more idiomatic ones in `integration-tests/modules/pse_test.go`, using `requireT.Empty` instead of `requireT.Len(..., 0)` for better clarity. [[1]](diffhunk://#diff-a123050a61ad3cfcf0b4566425f9597b520dbc78a4c9cef832f5d33b02e72968L341-R341) [[2]](diffhunk://#diff-a123050a61ad3cfcf0b4566425f9597b520dbc78a4c9cef832f5d33b02e72968L393-R393)

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/94)
<!-- Reviewable:end -->
