### PR TITLE
Fix random CI failure for TestFeeGrant integration test

### DIFF
--- a/integration-tests/modules/feegrant_test.go
+++ b/integration-tests/modules/feegrant_test.go
@@ -3,6 +3,7 @@
 package modules
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,12 +13,14 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	cosmoserrors "github.com/cosmos/cosmos-sdk/types/errors"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/pkg/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
 
 	integrationtests "github.com/tokenize-x/tx-chain/v7/integration-tests"
 	"github.com/tokenize-x/tx-chain/v7/pkg/client"
 	"github.com/tokenize-x/tx-chain/v7/testutil/integration"
+	"github.com/tokenize-x/tx-tools/pkg/retry"
 )
 
 func TestFeeGrant(t *testing.T) {
@@ -72,9 +75,10 @@ func TestFeeGrant(t *testing.T) {
 	latestBlock, err := chain.LatestBlockHeader(ctx)
 	requireT.NoError(err)
 
+	allowanceExpiration := latestBlock.Time.Add(10 * time.Second)
 	expiringAllowance, err := codectypes.NewAnyWithValue(&feegrant.BasicAllowance{
 		SpendLimit: nil, // empty means no limit
-		Expiration: lo.ToPtr(latestBlock.Time.Add(10 * time.Second)),
+		Expiration: lo.ToPtr(allowanceExpiration),
 	})
 	requireT.NoError(err)
 
@@ -98,8 +102,20 @@ func TestFeeGrant(t *testing.T) {
 	requireT.NoError(err)
 	requireT.Len(allowancesRes.Allowances, 2)
 
-	// await next 5 blocks
-	requireT.NoError(client.AwaitNextBlocks(ctx, chain.ClientContext, 10))
+	// await until chain time passes the allowance expiration
+	requireT.NoError(chain.AwaitState(ctx, func(ctx context.Context) error {
+		header, err := chain.LatestBlockHeader(ctx)
+		if err != nil {
+			return err
+		}
+		if !header.Time.After(allowanceExpiration) {
+			return retry.Retryable(errors.Errorf(
+				"chain time %s has not passed expiration %s yet",
+				header.Time, allowanceExpiration,
+			))
+		}
+		return nil
+	}))
 
 	pruneAllowancesMsg := &feegrant.MsgPruneAllowances{
 		Pruner: granter.String(),

--- a/integration-tests/modules/feegrant_test.go
+++ b/integration-tests/modules/feegrant_test.go
@@ -20,7 +20,6 @@ import (
 	integrationtests "github.com/tokenize-x/tx-chain/v7/integration-tests"
 	"github.com/tokenize-x/tx-chain/v7/pkg/client"
 	"github.com/tokenize-x/tx-chain/v7/testutil/integration"
-	"github.com/tokenize-x/tx-tools/pkg/retry"
 )
 
 func TestFeeGrant(t *testing.T) {
@@ -109,10 +108,10 @@ func TestFeeGrant(t *testing.T) {
 			return err
 		}
 		if !header.Time.After(allowanceExpiration) {
-			return retry.Retryable(errors.Errorf(
+			return errors.Errorf(
 				"chain time %s has not passed expiration %s yet",
 				header.Time, allowanceExpiration,
-			))
+			)
 		}
 		return nil
 	}))


### PR DESCRIPTION
# Description
This PR fixes random CI failure for upgrade integration tests, reported in https://app.clickup.com/t/868gpr0g3

`TestFeeGrant` sets an allowance expiration to `blockTime + 10s`, then calls `AwaitNextBlocks(10)` before pruning. 
With `TimeoutCommit` at **500ms**, 10 blocks ≈ 5-6s of chain time — not enough for expiration. Prune becomes bypassed and the assertion fails.

It's random because under heavy CI load, the blocks might be slower (pushing 10 blocks past the 10s threshold).

**Proposed Solution:** Fixed by replacing `AwaitNextBlocks` with `AwaitState`, which polls the latest block
timestamp until it exceeds the expiration. This guarantees the allowance is expired before pruning, regardless of block production speed.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/99)
<!-- Reviewable:end -->
