### PR TITLE
[hotfix]: Fix PSE division by zero in distributeToDelegator

### DIFF
--- a/x/pse/keeper/distribute.go
+++ b/x/pse/keeper/distribute.go
@@ -127,7 +127,7 @@ func (k Keeper) distributeToDelegator(
 		totalDelegationAmount = totalDelegationAmount.Add(delegation.Balance.Amount)
 	}
 
-	if len(delegations) == 0 {
+	if len(delegations) == 0 || totalDelegationAmount.IsZero() {
 		return sdkmath.NewInt(0), nil
 	}
 

--- a/x/pse/keeper/distribute_test.go
+++ b/x/pse/keeper/distribute_test.go
@@ -119,9 +119,10 @@ func TestKeeper_Distribute_DelegationWithZeroBalanceAfterSlash(t *testing.T) {
 	requireT.NoError(err)
 	distributeAmount := sdkmath.NewInt(10_000)
 	macc := testApp.AccountKeeper.GetModuleAccount(ctx, types.ClearingAccountCommunity)
-	requireT.NoError(testApp.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin(bondDenom, distributeAmount))))
+	distributeCoin := sdk.NewCoins(sdk.NewCoin(bondDenom, distributeAmount))
+	requireT.NoError(testApp.BankKeeper.MintCoins(ctx, minttypes.ModuleName, distributeCoin))
 	requireT.NoError(testApp.BankKeeper.SendCoinsFromModuleToModule(
-		ctx, minttypes.ModuleName, macc.GetName(), sdk.NewCoins(sdk.NewCoin(bondDenom, distributeAmount)),
+		ctx, minttypes.ModuleName, macc.GetName(), distributeCoin,
 	))
 	t.Logf("Funded PSE community clearing account with %s", distributeAmount)
 

--- a/x/pse/keeper/distribute_test.go
+++ b/x/pse/keeper/distribute_test.go
@@ -19,6 +19,121 @@ import (
 	"github.com/tokenize-x/tx-chain/v6/x/pse/types"
 )
 
+func TestKeeper_Distribute_DelegationWithZeroBalanceAfterSlash(t *testing.T) {
+	requireT := require.New(t)
+
+	startTime := time.Now().Round(time.Second)
+	testApp := simapp.New(simapp.WithStartTime(startTime))
+	ctx, _, err := testApp.BeginNextBlockAtTime(startTime)
+	requireT.NoError(err)
+
+	// Using the genesis validator which is already bonded.
+	bondedVals, err := testApp.StakingKeeper.GetBondedValidatorsByPower(ctx)
+	requireT.NoError(err)
+	requireT.NotEmpty(bondedVals, "should have at least one bonded genesis validator")
+	val := bondedVals[0]
+	valAddr := sdk.MustValAddressFromBech32(val.GetOperator())
+	consAddr, err := val.GetConsAddr()
+	requireT.NoError(err)
+
+	// Delegator A: delegates 500K amount to build score.
+	delegatorA, _ := testApp.GenAccount(ctx)
+	requireT.NoError(testApp.FundAccount(
+		ctx, delegatorA, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(1_000_000))),
+	))
+	_, err = stakingkeeper.NewMsgServerImpl(testApp.StakingKeeper).Delegate(ctx, &stakingtypes.MsgDelegate{
+		DelegatorAddress: delegatorA.String(),
+		ValidatorAddress: valAddr.String(),
+		Amount:           sdk.NewInt64Coin(sdk.DefaultBondDenom, 500_000),
+	})
+	requireT.NoError(err)
+	t.Logf("Delegator A delegated 500,000 to validator %s", valAddr)
+
+	// Delegator B: 500K delegation for score comparison.
+	delegatorB, _ := testApp.GenAccount(ctx)
+	requireT.NoError(testApp.FundAccount(
+		ctx, delegatorB, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(1_000_000))),
+	))
+	_, err = stakingkeeper.NewMsgServerImpl(testApp.StakingKeeper).Delegate(ctx, &stakingtypes.MsgDelegate{
+		DelegatorAddress: delegatorB.String(),
+		ValidatorAddress: valAddr.String(),
+		Amount:           sdk.NewInt64Coin(sdk.DefaultBondDenom, 500_000),
+	})
+	requireT.NoError(err)
+	t.Logf("Delegator B delegated 500,000 to validator %s", valAddr)
+
+	// Wait for score to accumulate (both delegators build equal score).
+	ctx, _, err = testApp.BeginNextBlockAtTime(ctx.BlockTime().Add(10 * time.Second))
+	requireT.NoError(err)
+	t.Log("Advanced 10 seconds for score accumulation")
+
+	// Delegator A undelegates 499,999 - almost everything, keeping only 1 token.
+	// The undelegation hook captures the accumulated score in AccountScoreSnapshot.
+	_, err = stakingkeeper.NewMsgServerImpl(testApp.StakingKeeper).Undelegate(ctx, &stakingtypes.MsgUndelegate{
+		DelegatorAddress: delegatorA.String(),
+		ValidatorAddress: valAddr.String(),
+		Amount:           sdk.NewInt64Coin(sdk.DefaultBondDenom, 499_999),
+	})
+	requireT.NoError(err)
+	t.Log("Delegator A undelegated 499,999 (keeping 1 token / 1 share)")
+
+	// Slash the validator by 99%.
+	// Delegator A's remaining 1 share → TokensFromShares(1) truncates to 0.
+	valPower := val.ConsensusPower(sdk.DefaultPowerReduction)
+	t.Logf("Slashing validator (power=%d) by 99%%", valPower)
+	_, err = testApp.StakingKeeper.Slash(
+		ctx,
+		consAddr,
+		ctx.BlockHeight()-1,
+		valPower,
+		sdkmath.LegacyMustNewDecFromStr("0.99"),
+	)
+	requireT.NoError(err)
+
+	// Verify delegator A's delegation exists but has zero token balance.
+	stakingQuerier := stakingkeeper.NewQuerier(testApp.StakingKeeper)
+	delegationsRsp, err := stakingQuerier.DelegatorDelegations(ctx, &stakingtypes.QueryDelegatorDelegationsRequest{
+		DelegatorAddr: delegatorA.String(),
+	})
+	requireT.NoError(err)
+	requireT.NotEmpty(delegationsRsp.DelegationResponses, "delegation should still exist (has shares)")
+	totalBalance := sdkmath.NewInt(0)
+	for _, d := range delegationsRsp.DelegationResponses {
+		t.Logf("Delegator A delegation: shares=%s, balance=%s", d.Delegation.Shares, d.Balance.Amount)
+		totalBalance = totalBalance.Add(d.Balance.Amount)
+	}
+	requireT.True(totalBalance.IsZero(),
+		"delegator A's balance should be zero after slash, got %s", totalBalance)
+	t.Logf("Delegator A: delegation exists (shares > 0) but token balance = %s", totalBalance)
+
+	// Verify delegator A has significant score (from the 500,000 * 10s period).
+	scoreA, err := testApp.PSEKeeper.CalculateDelegatorScore(ctx, delegatorA)
+	requireT.NoError(err)
+	requireT.True(scoreA.IsPositive(), "delegator A should have positive score, got %s", scoreA)
+	scoreB, err := testApp.PSEKeeper.CalculateDelegatorScore(ctx, delegatorB)
+	requireT.NoError(err)
+	t.Logf("Scores — delegator A: %s, delegator B: %s", scoreA, scoreB)
+
+	// Fund the PSE community clearing account and distribute.
+	bondDenom, err := testApp.StakingKeeper.BondDenom(ctx)
+	requireT.NoError(err)
+	distributeAmount := sdkmath.NewInt(10_000)
+	macc := testApp.AccountKeeper.GetModuleAccount(ctx, types.ClearingAccountCommunity)
+	requireT.NoError(testApp.BankKeeper.MintCoins(ctx, minttypes.ModuleName, sdk.NewCoins(sdk.NewCoin(bondDenom, distributeAmount))))
+	requireT.NoError(testApp.BankKeeper.SendCoinsFromModuleToModule(
+		ctx, minttypes.ModuleName, macc.GetName(), sdk.NewCoins(sdk.NewCoin(bondDenom, distributeAmount)),
+	))
+	t.Logf("Funded PSE community clearing account with %s", distributeAmount)
+
+	// Should trigger panic with "Division by zero" in distributeToDelegator (if fix is not applied)
+	// because delegator A gets a non-zero amount (has high score) but their totalDelegationAmount is 0.
+	scheduledAt := uint64(ctx.BlockTime().Unix())
+	t.Log("Running DistributeCommunityPSE...")
+	err = testApp.PSEKeeper.DistributeCommunityPSE(ctx, bondDenom, distributeAmount, scheduledAt)
+	requireT.NoError(err)
+	t.Log("Distribution completed successfully (no division by zero panic)")
+}
+
 func TestKeeper_Distribute(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/x/pse/keeper/distribute_test.go
+++ b/x/pse/keeper/distribute_test.go
@@ -19,122 +19,6 @@ import (
 	"github.com/tokenize-x/tx-chain/v6/x/pse/types"
 )
 
-func TestKeeper_Distribute_DelegationWithZeroBalanceAfterSlash(t *testing.T) {
-	requireT := require.New(t)
-
-	startTime := time.Now().Round(time.Second)
-	testApp := simapp.New(simapp.WithStartTime(startTime))
-	ctx, _, err := testApp.BeginNextBlockAtTime(startTime)
-	requireT.NoError(err)
-
-	// Using the genesis validator which is already bonded.
-	bondedVals, err := testApp.StakingKeeper.GetBondedValidatorsByPower(ctx)
-	requireT.NoError(err)
-	requireT.NotEmpty(bondedVals, "should have at least one bonded genesis validator")
-	val := bondedVals[0]
-	valAddr := sdk.MustValAddressFromBech32(val.GetOperator())
-	consAddr, err := val.GetConsAddr()
-	requireT.NoError(err)
-
-	// Delegator A: delegates 500K amount to build score.
-	delegatorA, _ := testApp.GenAccount(ctx)
-	requireT.NoError(testApp.FundAccount(
-		ctx, delegatorA, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(1_000_000))),
-	))
-	_, err = stakingkeeper.NewMsgServerImpl(testApp.StakingKeeper).Delegate(ctx, &stakingtypes.MsgDelegate{
-		DelegatorAddress: delegatorA.String(),
-		ValidatorAddress: valAddr.String(),
-		Amount:           sdk.NewInt64Coin(sdk.DefaultBondDenom, 500_000),
-	})
-	requireT.NoError(err)
-	t.Logf("Delegator A delegated 500,000 to validator %s", valAddr)
-
-	// Delegator B: 500K delegation for score comparison.
-	delegatorB, _ := testApp.GenAccount(ctx)
-	requireT.NoError(testApp.FundAccount(
-		ctx, delegatorB, sdk.NewCoins(sdk.NewCoin(sdk.DefaultBondDenom, sdkmath.NewInt(1_000_000))),
-	))
-	_, err = stakingkeeper.NewMsgServerImpl(testApp.StakingKeeper).Delegate(ctx, &stakingtypes.MsgDelegate{
-		DelegatorAddress: delegatorB.String(),
-		ValidatorAddress: valAddr.String(),
-		Amount:           sdk.NewInt64Coin(sdk.DefaultBondDenom, 500_000),
-	})
-	requireT.NoError(err)
-	t.Logf("Delegator B delegated 500,000 to validator %s", valAddr)
-
-	// Wait for score to accumulate (both delegators build equal score).
-	ctx, _, err = testApp.BeginNextBlockAtTime(ctx.BlockTime().Add(10 * time.Second))
-	requireT.NoError(err)
-	t.Log("Advanced 10 seconds for score accumulation")
-
-	// Delegator A undelegates 499,999 - almost everything, keeping only 1 token.
-	// The undelegation hook captures the accumulated score in AccountScoreSnapshot.
-	_, err = stakingkeeper.NewMsgServerImpl(testApp.StakingKeeper).Undelegate(ctx, &stakingtypes.MsgUndelegate{
-		DelegatorAddress: delegatorA.String(),
-		ValidatorAddress: valAddr.String(),
-		Amount:           sdk.NewInt64Coin(sdk.DefaultBondDenom, 499_999),
-	})
-	requireT.NoError(err)
-	t.Log("Delegator A undelegated 499,999 (keeping 1 token / 1 share)")
-
-	// Slash the validator by 99%.
-	// Delegator A's remaining 1 share → TokensFromShares(1) truncates to 0.
-	valPower := val.ConsensusPower(sdk.DefaultPowerReduction)
-	t.Logf("Slashing validator (power=%d) by 99%%", valPower)
-	_, err = testApp.StakingKeeper.Slash(
-		ctx,
-		consAddr,
-		ctx.BlockHeight()-1,
-		valPower,
-		sdkmath.LegacyMustNewDecFromStr("0.99"),
-	)
-	requireT.NoError(err)
-
-	// Verify delegator A's delegation exists but has zero token balance.
-	stakingQuerier := stakingkeeper.NewQuerier(testApp.StakingKeeper)
-	delegationsRsp, err := stakingQuerier.DelegatorDelegations(ctx, &stakingtypes.QueryDelegatorDelegationsRequest{
-		DelegatorAddr: delegatorA.String(),
-	})
-	requireT.NoError(err)
-	requireT.NotEmpty(delegationsRsp.DelegationResponses, "delegation should still exist (has shares)")
-	totalBalance := sdkmath.NewInt(0)
-	for _, d := range delegationsRsp.DelegationResponses {
-		t.Logf("Delegator A delegation: shares=%s, balance=%s", d.Delegation.Shares, d.Balance.Amount)
-		totalBalance = totalBalance.Add(d.Balance.Amount)
-	}
-	requireT.True(totalBalance.IsZero(),
-		"delegator A's balance should be zero after slash, got %s", totalBalance)
-	t.Logf("Delegator A: delegation exists (shares > 0) but token balance = %s", totalBalance)
-
-	// Verify delegator A has significant score (from the 500,000 * 10s period).
-	scoreA, err := testApp.PSEKeeper.CalculateDelegatorScore(ctx, delegatorA)
-	requireT.NoError(err)
-	requireT.True(scoreA.IsPositive(), "delegator A should have positive score, got %s", scoreA)
-	scoreB, err := testApp.PSEKeeper.CalculateDelegatorScore(ctx, delegatorB)
-	requireT.NoError(err)
-	t.Logf("Scores — delegator A: %s, delegator B: %s", scoreA, scoreB)
-
-	// Fund the PSE community clearing account and distribute.
-	bondDenom, err := testApp.StakingKeeper.BondDenom(ctx)
-	requireT.NoError(err)
-	distributeAmount := sdkmath.NewInt(10_000)
-	macc := testApp.AccountKeeper.GetModuleAccount(ctx, types.ClearingAccountCommunity)
-	distributeCoin := sdk.NewCoins(sdk.NewCoin(bondDenom, distributeAmount))
-	requireT.NoError(testApp.BankKeeper.MintCoins(ctx, minttypes.ModuleName, distributeCoin))
-	requireT.NoError(testApp.BankKeeper.SendCoinsFromModuleToModule(
-		ctx, minttypes.ModuleName, macc.GetName(), distributeCoin,
-	))
-	t.Logf("Funded PSE community clearing account with %s", distributeAmount)
-
-	// Should trigger panic with "Division by zero" in distributeToDelegator (if fix is not applied)
-	// because delegator A gets a non-zero amount (has high score) but their totalDelegationAmount is 0.
-	scheduledAt := uint64(ctx.BlockTime().Unix())
-	t.Log("Running DistributeCommunityPSE...")
-	err = testApp.PSEKeeper.DistributeCommunityPSE(ctx, bondDenom, distributeAmount, scheduledAt)
-	requireT.NoError(err)
-	t.Log("Distribution completed successfully (no division by zero panic)")
-}
-
 func TestKeeper_Distribute(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -299,6 +183,25 @@ func TestKeeper_Distribute(t *testing.T) {
 				func(r *runEnv) { assertScoreResetAction(r) },
 			},
 		},
+		{
+			name: "test delegation with zero balance after slash",
+			actions: []func(*runEnv){
+				func(r *runEnv) {
+					delegateAction(r, r.delegators[0], r.validators[3], 500_000)
+				},
+				func(r *runEnv) {
+					delegateAction(r, r.delegators[1], r.validators[3], 500_000)
+				},
+				func(r *runEnv) { waitAction(r, time.Second*10) },
+				func(r *runEnv) {
+					undelegateAction(r, r.delegators[0], r.validators[3], 499_999)
+				},
+				// Slash 99%: delegator[0]'s 1 share truncates to 0 tokens.
+				func(r *runEnv) { slashAction(r, r.validators[3], "0.99") },
+				// Distribution should not panic (delegator[0] has score but 0 delegation balance).
+				func(r *runEnv) { distributeAction(r, sdkmath.NewInt(10_000)) },
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -314,7 +217,7 @@ func TestKeeper_Distribute(t *testing.T) {
 				requireT: requireT,
 			}
 
-			// add validators.
+			// add validators (indices 0-2: unbonded via AddValidator).
 			for range 3 {
 				validatorOperator, _ := testApp.GenAccount(ctx)
 				requireT.NoError(testApp.FundAccount(
@@ -329,6 +232,14 @@ func TestKeeper_Distribute(t *testing.T) {
 					sdk.MustValAddressFromBech32(validator.GetOperator()),
 				)
 			}
+
+			bondedVals, err := testApp.StakingKeeper.GetBondedValidatorsByPower(ctx)
+			requireT.NoError(err)
+			requireT.NotEmpty(bondedVals)
+			runContext.validators = append(
+				runContext.validators,
+				sdk.MustValAddressFromBech32(bondedVals[0].GetOperator()),
+			)
 
 			// add delegators.
 			for range 3 {

--- a/x/pse/keeper/hooks_test.go
+++ b/x/pse/keeper/hooks_test.go
@@ -343,6 +343,19 @@ func redelegateAction(
 	r.requireT.NoError(err)
 }
 
+func slashAction(r *runEnv, valAddr sdk.ValAddress, fraction string) {
+	val, err := r.testApp.StakingKeeper.GetValidator(r.ctx, valAddr)
+	r.requireT.NoError(err)
+	consAddr, err := val.GetConsAddr()
+	r.requireT.NoError(err)
+	power := val.ConsensusPower(sdk.DefaultPowerReduction)
+	_, err = r.testApp.StakingKeeper.Slash(
+		r.ctx, consAddr, r.ctx.BlockHeight()-1, power,
+		sdkmath.LegacyMustNewDecFromStr(fraction),
+	)
+	r.requireT.NoError(err)
+}
+
 func waitAction(r *runEnv, duration time.Duration) {
 	ctx, _, err := r.testApp.BeginNextBlockAtTime(r.ctx.BlockTime().Add(duration))
 	r.requireT.NoError(err)


### PR DESCRIPTION
# Description
Guard against division by zero when a delegator has score but zero delegation token balance (e.g., after validator slashing). Adds distribution test reproducing the exact testnet crash.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/101)
<!-- Reviewable:end -->
