### PR TITLE
Fix missing DenomUnits in v6 denom metadata migration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -132,6 +132,7 @@ import (
 	"github.com/tokenize-x/tx-chain/v6/app/openapi"
 	appupgrade "github.com/tokenize-x/tx-chain/v6/app/upgrade"
 	appupgradev6 "github.com/tokenize-x/tx-chain/v6/app/upgrade/v6"
+	appupgradev6fixdenommetadata "github.com/tokenize-x/tx-chain/v6/app/upgrade/v6_fix_denom_metadata"
 	"github.com/tokenize-x/tx-chain/v6/docs"
 	"github.com/tokenize-x/tx-chain/v6/pkg/config"
 	"github.com/tokenize-x/tx-chain/v6/pkg/config/constant"
@@ -1202,6 +1203,11 @@ func New(
 			app.PSEKeeper,
 			app.AccountKeeper.AddressCodec(),
 			app.StakingKeeper.ValidatorAddressCodec(),
+		),
+		appupgradev6fixdenommetadata.New(
+			app.ModuleManager,
+			app.configurator,
+			app.BankKeeper,
 		),
 	}
 

--- a/app/upgrade/v6_fix_denom_metadata/denom_metadata.go
+++ b/app/upgrade/v6_fix_denom_metadata/denom_metadata.go
@@ -1,0 +1,49 @@
+package v6fixdenommetadata
+
+import (
+	"context"
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/tokenize-x/tx-chain/v6/pkg/config/constant"
+	wbankkeeper "github.com/tokenize-x/tx-chain/v6/x/wbank/keeper"
+)
+
+// MigrateDenomMetadata fixes the DenomUnits that were missed in the v6 migration.
+func MigrateDenomMetadata(ctx context.Context, bankKeeper wbankkeeper.BaseKeeperWrapper) error {
+	var denom string
+	var prefix string
+
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	switch sdkCtx.ChainID() {
+	case string(constant.ChainIDMain):
+		denom = constant.DenomMain
+		prefix = ""
+	case string(constant.ChainIDTest):
+		denom = constant.DenomTest
+		prefix = "test"
+	case string(constant.ChainIDDev):
+		denom = constant.DenomDev
+		prefix = "dev"
+	default:
+		return fmt.Errorf("unknown chain id: %s", sdkCtx.ChainID())
+	}
+
+	meta, found := bankKeeper.GetDenomMetaData(ctx, denom)
+	if !found {
+		return fmt.Errorf("denom metadata not found for %s", denom)
+	}
+
+	displayDenom := prefix + "tx"
+	for i, unit := range meta.DenomUnits {
+		if unit.Exponent == 6 {
+			meta.DenomUnits[i].Denom = displayDenom
+		}
+	}
+
+	bankKeeper.SetDenomMetaData(ctx, meta)
+
+	return nil
+}

--- a/app/upgrade/v6_fix_denom_metadata/denom_metadata_test.go
+++ b/app/upgrade/v6_fix_denom_metadata/denom_metadata_test.go
@@ -1,0 +1,60 @@
+package v6fixdenommetadata_test
+
+import (
+	"testing"
+	"time"
+
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+
+	v6fixdenommetadata "github.com/tokenize-x/tx-chain/v6/app/upgrade/v6_fix_denom_metadata"
+	"github.com/tokenize-x/tx-chain/v6/pkg/config/constant"
+	"github.com/tokenize-x/tx-chain/v6/testutil/simapp"
+)
+
+func TestMigrateDenomMetadata(t *testing.T) {
+	requireT := require.New(t)
+
+	testApp := simapp.New()
+	ctx := testApp.NewContext(false).
+		WithChainID(string(constant.ChainIDDev)).
+		WithBlockTime(time.Now())
+
+	// Reproduce the broken on-chain state left by v6: Display, Description, Symbol were
+	// rebranded to "tx" but DenomUnits was missed, leaving "devcore" at exponent 6.
+	testApp.BankKeeper.SetDenomMetaData(ctx, banktypes.Metadata{
+		Description: "devtx coin",
+		DenomUnits: []*banktypes.DenomUnit{
+			{Denom: constant.DenomDev, Exponent: 0},
+			{Denom: constant.DenomDevDisplay, Exponent: 6}, // "devcore" - not updated by v6
+		},
+		Base:    constant.DenomDev,
+		Display: "devtx", // updated by v6
+		Name:    constant.DenomDev,
+		Symbol:  "udevtx",
+	})
+
+	// Verify the inconsistent state before fix
+	meta, found := testApp.BankKeeper.GetDenomMetaData(ctx, constant.DenomDev)
+	requireT.True(found)
+	requireT.Equal("devtx", meta.Display)
+	requireT.Equal("devcore", meta.DenomUnits[1].Denom)
+
+	// Run the fix
+	err := v6fixdenommetadata.MigrateDenomMetadata(ctx, testApp.BankKeeper)
+	requireT.NoError(err)
+
+	// Verify the fix
+	meta, found = testApp.BankKeeper.GetDenomMetaData(ctx, constant.DenomDev)
+	requireT.True(found)
+	requireT.Equal("devtx", meta.Display)
+	requireT.Equal("devtx", meta.DenomUnits[1].Denom)
+	requireT.Equal(uint32(6), meta.DenomUnits[1].Exponent)
+
+	// Verify base unit unchanged
+	requireT.Equal(constant.DenomDev, meta.DenomUnits[0].Denom)
+	requireT.Equal(uint32(0), meta.DenomUnits[0].Exponent)
+
+	// Verify the metadata passes validation
+	requireT.NoError(meta.Validate())
+}

--- a/app/upgrade/v6_fix_denom_metadata/upgrade.go
+++ b/app/upgrade/v6_fix_denom_metadata/upgrade.go
@@ -1,0 +1,37 @@
+package v6fixdenommetadata
+
+import (
+	"context"
+
+	store "cosmossdk.io/store/types"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/tokenize-x/tx-chain/v6/app/upgrade"
+	wbankkeeper "github.com/tokenize-x/tx-chain/v6/x/wbank/keeper"
+)
+
+// Name defines the upgrade name.
+const Name = "v6_fix_denom_metadata"
+
+// New makes an upgrade handler for v6_fix_denom_metadata upgrade.
+func New(
+	mm *module.Manager,
+	configurator module.Configurator,
+	bankKeeper wbankkeeper.BaseKeeperWrapper,
+) upgrade.Upgrade {
+	return upgrade.Upgrade{
+		Name: Name,
+		StoreUpgrades: store.StoreUpgrades{
+			Added:   []string{},
+			Deleted: []string{},
+		},
+		Upgrade: func(ctx context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+			if err := MigrateDenomMetadata(ctx, bankKeeper); err != nil {
+				return nil, err
+			}
+
+			return mm.RunMigrations(ctx, configurator, vm)
+		},
+	}
+}


### PR DESCRIPTION
# Description
The v6 upgrade updated `Display` to "tx" but missed updating `DenomUnits` - it still has "core" at exponent 6. This blocks the Cosmos Chain Registry update ([cosmos/chain-registry#7564](https://github.com/cosmos/chain-registry/pull/7564#issuecomment-4011152648)) since the CI requires `Display` to match a `DenomUnits` entry.

This adds a new upgrade handler `v6_fix_denom_metadata` that renames `DenomUnits[exponent=6]` from "core" to "tx" to match `Display`. 

Will be Released as `v6.1.0`.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/103)
<!-- Reviewable:end -->
