### PR TITLE
[multiblock-PSE] Fix possible failures in delegation phase

### DIFF
--- a/x/pse/keeper/distribute.go
+++ b/x/pse/keeper/distribute.go
@@ -377,6 +377,11 @@ func (k Keeper) distributeToDelegator(
 	}
 
 	for _, delegation := range delegations {
+		// Skip fully-slashed validators (Balance=0) and auto-delegate only to healthy ones.
+		// Otherwise SDK Delegate returns ErrDelegatorShareExRateInvalid and disables PSE.
+		if delegation.Balance.Amount.IsZero() {
+			continue
+		}
 		// NOTE: this division will have rounding errors up to 1 subunit, which is acceptable and will be ignored.
 		// if that one subunit exists, it will remain in user balance as undelegated.
 		delegationAmount := delegation.Balance.Amount.Mul(amount).Quo(totalDelegationAmount)

--- a/x/pse/keeper/distribute_test.go
+++ b/x/pse/keeper/distribute_test.go
@@ -881,3 +881,131 @@ func TestCommunityIntermediary_FundIsolation(t *testing.T) {
 	requireT.Equal(remaining, testApp.BankKeeper.GetBalance(ctx, communityAddr, bondDenom).Amount,
 		"pse_community must still hold future rounds' funds untouched after distribution")
 }
+
+// TestDistribution_SlashedValidator_RedirectsRewardToHealthy verifies that when a delegator has
+// stake on one healthy and one fully-slashed validator, PSE Phase 2 skips the slashed validator
+// and routes the delegator's full reward to the healthy validator(s) instead. Without the fix,
+// Phase 2 calls Delegate(slashedVal, 0) which returns ErrDelegatorShareExRateInvalid and disables PSE.
+func TestDistribution_SlashedValidator_RedirectsRewardToHealthy(t *testing.T) {
+	requireT := require.New(t)
+
+	testApp := simapp.New()
+	pseKeeper := testApp.PSEKeeper
+	stakingKeeper := testApp.StakingKeeper
+
+	// Use explicit timing so Phase 1 produces a positive score.
+	t0 := time.Now().UTC().Round(time.Second)
+	ctx, _, err := testApp.BeginNextBlockAtTime(t0)
+	requireT.NoError(err)
+	bondDenom, err := stakingKeeper.BondDenom(ctx)
+	requireT.NoError(err)
+
+	// Two validators (slashed + healthy) and a delegator with stake on both.
+	makeValidator := func() sdk.ValAddress {
+		op, _ := testApp.GenAccount(ctx)
+		requireT.NoError(testApp.FundAccount(ctx, op, sdk.NewCoins(sdk.NewCoin(bondDenom, sdkmath.NewInt(1_000)))))
+		val, err := testApp.AddValidator(ctx, op, sdk.NewInt64Coin(bondDenom, 10), nil)
+		requireT.NoError(err)
+		return sdk.MustValAddressFromBech32(val.GetOperator())
+	}
+	valSlashedAddr := makeValidator()
+	valHealthyAddr := makeValidator()
+
+	delAddr, _ := testApp.GenAccount(ctx)
+	requireT.NoError(testApp.FundAccount(ctx, delAddr, sdk.NewCoins(sdk.NewCoin(bondDenom, sdkmath.NewInt(10_000)))))
+
+	const delegationAmt = int64(1_000)
+	delegate := func(val sdk.ValAddress, amt int64) {
+		_, err := stakingkeeper.NewMsgServerImpl(stakingKeeper).Delegate(ctx, &stakingtypes.MsgDelegate{
+			DelegatorAddress: delAddr.String(),
+			ValidatorAddress: val.String(),
+			Amount:           sdk.NewInt64Coin(bondDenom, amt),
+		})
+		requireT.NoError(err)
+	}
+	delegate(valSlashedAddr, delegationAmt)
+	delegate(valHealthyAddr, delegationAmt)
+
+	// Schedule timestamp 5 seconds after delegations so Phase 1 produces score.
+	scheduleTimestamp := t0.Add(5 * time.Second)
+	requireT.NoError(pseKeeper.SaveDistributionSchedule(ctx, []types.ScheduledDistribution{{
+		ID:        firstDistributionID,
+		Timestamp: uint64(scheduleTimestamp.Unix()),
+		Allocations: []types.ClearingAccountAllocation{{
+			ClearingAccount: types.ClearingAccountCommunity,
+			Amount:          sdkmath.NewInt(10_000_000),
+		}},
+	}}))
+
+	// Post-100%-slash state on valSlashed: Tokens=0, DelegatorShares unchanged.
+	valSlashed, err := stakingKeeper.GetValidator(ctx, valSlashedAddr)
+	requireT.NoError(err)
+	valSlashed.Tokens = sdkmath.ZeroInt()
+	requireT.NoError(stakingKeeper.SetValidator(ctx, valSlashed))
+
+	// Fund the community clearing account.
+	communityCoins := sdk.NewCoins(sdk.NewCoin(bondDenom, sdkmath.NewInt(10_000_000)))
+	macc := testApp.AccountKeeper.GetModuleAccount(ctx, types.ClearingAccountCommunity)
+	requireT.NoError(testApp.BankKeeper.MintCoins(ctx, minttypes.ModuleName, communityCoins))
+	requireT.NoError(testApp.BankKeeper.SendCoinsFromModuleToModule(
+		ctx, minttypes.ModuleName, macc.GetName(), communityCoins,
+	))
+
+	// Capture wallet + healthy delegation balances right before the distribution starts.
+	walletBefore := testApp.BankKeeper.GetBalance(ctx, delAddr, bondDenom).Amount
+	healthyBefore := func() sdkmath.Int {
+		d, derr := stakingKeeper.GetDelegation(ctx, delAddr, valHealthyAddr)
+		requireT.NoError(derr)
+		val, verr := stakingKeeper.GetValidator(ctx, valHealthyAddr)
+		requireT.NoError(verr)
+		return val.TokensFromShares(d.Shares).TruncateInt()
+	}()
+
+	// Trigger block at t0+10s which will set OngoingDistribution.
+	requireT.NoError(testApp.FinalizeBlockAtTime(t0.Add(10 * time.Second)))
+
+	// Phase 1 batch + Phase 2 first batch (pays the delegator).
+	// Slashed validator should be skipped and entire userAmount should be paid to the healthy one.
+	requireT.NoError(testApp.FinalizeBlockAtTime(t0.Add(15 * time.Second)))
+
+	// Phase 2 second batch is empty. cleanup -> lastProcessed advances.
+	requireT.NoError(testApp.FinalizeBlockAtTime(t0.Add(20 * time.Second)))
+
+	ctx, _, err = testApp.BeginNextBlockAtTime(t0.Add(25 * time.Second))
+	requireT.NoError(err)
+
+	// PSE must NOT be disabled — the fix kept the failing path from firing.
+	disabled, err := pseKeeper.DistributionDisabled.Get(ctx)
+	requireT.NoError(err)
+	requireT.False(disabled, "PSE must not be disabled — the slashed validator's slice was skipped")
+
+	// LastProcessedDistributionID must have advanced — distribution finalized successfully.
+	lastProcessed, err := pseKeeper.LastProcessedDistributionID.Get(ctx)
+	requireT.NoError(err)
+	requireT.Equal(firstDistributionID, lastProcessed, "distribution must have finalized")
+
+	// Verify the slashed validator's slice was fully redirected to the healthy validator:
+	walletAfter := testApp.BankKeeper.GetBalance(ctx, delAddr, bondDenom).Amount
+	walletLeftover := walletAfter.Sub(walletBefore)
+	requireT.True(walletLeftover.LTE(sdkmath.NewInt(1)),
+		"wallet leftover=%s exceeds 1 subunit — reward was not fully auto-delegated to the healthy validator",
+		walletLeftover)
+
+	stakingQuerier := stakingkeeper.NewQuerier(stakingKeeper)
+	delResp, err := stakingQuerier.DelegatorDelegations(ctx, &stakingtypes.QueryDelegatorDelegationsRequest{
+		DelegatorAddr: delAddr.String(),
+	})
+	requireT.NoError(err)
+	requireT.Len(delResp.DelegationResponses, 2)
+	for _, d := range delResp.DelegationResponses {
+		switch d.Delegation.ValidatorAddress {
+		case valHealthyAddr.String():
+			healthyGrowth := d.Balance.Amount.Sub(healthyBefore)
+			requireT.True(healthyGrowth.IsPositive(),
+				"healthy validator delegation must have grown from auto-delegate (got growth=%s)", healthyGrowth)
+		case valSlashedAddr.String():
+			requireT.True(d.Balance.Amount.IsZero(),
+				"slashed validator delegation Balance must remain zero (validator.Tokens=0)")
+		}
+	}
+}


### PR DESCRIPTION
Closes: https://app.clickup.com/t/868j5ydyz
# Description
## Problem
In PSE reward distribution phase, `distributeToDelegator` function calls `stakingKeeper.Delegate(...)` once per validator the delegator has stake on. If one validator is 100%-slashed (`Tokens=0`, `Shares>0`), SDK returns `ErrDelegatorShareExRateInvalid` from the `x/staking` module, which propagates to `EndBlock` and disables PSE chain-wide. 

The existing` totalDelegationAmount.IsZero() `check only fires **when ALL of the delegator's validators are fully slashed** (so the sum of balances is zero). It does NOT fire in the mixed case, **where the delegator has at least one healthy validator alongside slashed ones** - `totalDelegationAmount` stays positive, the early-return is skipped, and the per-validator loop reaches the slashed one and triggers `ErrDelegatorShareExRateInvalid`.

The exact scenario described above is produced with unit tests, which resulted in PSE being disabled due to returned error from the Staking module.

## Fix
Skip zero-balance delegations in the per-validator loop. The proportional split formula already excludes them from the denominator, so the slashed slice is naturally redirected to healthy validators with no leftover. The delegator receives their full reward; but it just lands entirely on healthy delegations.

## Why only this error is handled

Staking module keeper method usages in multi-block PSE reviewed: `stakingKeeper.Delegate`, `GetValidator`, `DelegatorDelegations`. Possible returned error cases are:

- `ErrDelegatorShareExRateInvalid`: fully-slashed validator; **fixed by this PR**.
- `ErrInsufficientFunds`: unreachable; PSE sends funds to the wallet right before `Delegate` in the same atomic call.
- `ErrInvalidCoins`: unreachable; `sdk.NewCoins` filters zero coins, `Delegate(val, 0)` is a silent no-op.
- `ErrNoValidatorFound`: unreachable; validator removal also removes the delegation row.
- KV / hook / panic errors:  genuinely critical; existing disable behavior is preserved.

Based on this assessment, only the fully-slashed validator case requires handling at the PSE layer. All other reachable failures are either unreachable in practice or genuinely critical and should keep the existing disable behavior.

## Tests
`TestDistribution_SlashedValidator_RedirectsRewardToHealthy`: full EndBlocker flow, asserts PSE not disabled, distribution finalized, slashed slice fully redirected to healthy validator (wallet leftover ≤ 1 subunit). Fails without the fix.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/119)
<!-- Reviewable:end -->
