### PR TITLE
Remove Unnecessary Retry from Network testutil

### DIFF
--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -1,9 +1,7 @@
 package network
 
 import (
-	"context"
 	"os"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -28,7 +26,6 @@ import (
 	"github.com/tokenize-x/tx-chain/v7/app"
 	"github.com/tokenize-x/tx-chain/v7/pkg/config"
 	"github.com/tokenize-x/tx-chain/v7/pkg/config/constant"
-	"github.com/tokenize-x/tx-tools/pkg/retry"
 )
 
 type (
@@ -58,24 +55,7 @@ func New(t *testing.T, configs ...network.Config) *network.Network {
 		cfg = configs[0]
 	}
 
-	var net *Network
-
-	// Sometimes another process already binds the port to bind to.
-	// So we need to retry to used another random port.
-	// TODO (v7): Remove the retry when upgrading to cosmos v0.52.x
-	retryCtx, retryCancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer retryCancel()
-	err := retry.Do(retryCtx, 2*time.Second, func() error {
-		n, err := network.New(t, t.TempDir(), cfg)
-		if err != nil {
-			if strings.Contains(err.Error(), "address already in use") {
-				return retry.Retryable(err)
-			}
-			return err
-		}
-		net = n
-		return nil
-	})
+	net, err := network.New(t, t.TempDir(), cfg)
 	require.NoError(t, err)
 	t.Cleanup(net.Cleanup)
 	return net


### PR DESCRIPTION
# Description

This pull request simplifies the `testutil/network/network.go` file by removing retry logic and related dependencies when creating a new test network. The code now directly creates the network without attempting to handle "address already in use" errors, reflecting a move toward simpler and more deterministic test setup.

**What cosmos SDK v0.52+ actually did (and v0.53.x has):**
In init(), the SDK now pre-allocates a portPool of 200 free TCP ports by calling FreeTCPAddr() for each (bind → get port → release), then uses those ports when creating test validators. This eliminates the race condition entirely — the workaround is no longer needed.

Dependency cleanup:

* Removed unused imports: `context`, `strings`, and `github.com/tokenize-x/tx-tools/pkg/retry`. [[1]](diffhunk://#diff-861dde2ecea6b928e6a5cd5e4a010c4a4539aeb7d359d26a29bcd0d151bc8b6cL4-L6) [[2]](diffhunk://#diff-861dde2ecea6b928e6a5cd5e4a010c4a4539aeb7d359d26a29bcd0d151bc8b6cL31)

Test setup simplification:

* Replaced the retry-based network creation logic in `New` with a direct call to `network.New`, eliminating the workaround for port conflicts.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/122)
<!-- Reviewable:end -->
