### PR TITLE
Set custom handler comment to be changed v8 on 2026 Q4

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -745,10 +745,10 @@ func New(
 			app.BankKeeper,
 			appCodec,
 			&app.TransferKeeper,
-			// TODO (v7): Remove legacy message handler.
+			// TODO (v8): Remove legacy message handler. Planned for 2026 Q4.
 			wasmcustomhandler.NewTXChainMsgHandler(),
 		))),
-		// TODO (v7): Remove legacy custom query handler, keep only GRPC queries.
+		// TODO (v8): Remove legacy custom query handler, keep only GRPC queries. Planned for 2026 Q4.
 		wasmkeeper.WithQueryPlugins(wasmcustomhandler.NewTXChainQueryHandler(
 			assetftkeeper.NewQueryService(app.AssetFTKeeper, app.BankKeeper),
 			assetnftkeeper.NewQueryService(app.AssetNFTKeeper),

--- a/x/wasm/handler/message.go
+++ b/x/wasm/handler/message.go
@@ -93,7 +93,7 @@ type txChainMsg struct {
 // NewTXChainMsgHandler returns tx-chain handler that handles messages received from smart contracts.
 // The in the input sender is the address of smart contract.
 // Deprecated: Supported for backward compatibility of legacy smart contracts only.
-// TODO (v7): Remove this legacy handler.
+// TODO (v8): Remove this legacy handler. Planned for 2026 Q4.
 func NewTXChainMsgHandler() *wasmkeeper.MessageEncoders {
 	return &wasmkeeper.MessageEncoders{
 		Custom: func(sender sdk.AccAddress, msg json.RawMessage) ([]sdk.Msg, error) {

--- a/x/wasm/handler/query.go
+++ b/x/wasm/handler/query.go
@@ -154,7 +154,7 @@ type txChainQuery struct {
 }
 
 // NewTXChainQueryHandler returns the tx-chain handler which handles queries from smart contracts.
-// TODO (v7): Remove the Custom query handler (processTXChainQuery) - it's deprecated for backward compatibility only.
+// TODO (v8): Remove the Custom query handler (processTXChainQuery) - it's deprecated for backward compatibility only. Planned for 2026 Q4.
 func NewTXChainQueryHandler(
 	assetFTQueryServer assetfttypes.QueryServer, assetNFTQueryServer assetnfttypes.QueryServer,
 	nftQueryServer nfttypes.QueryServer, gRPCQueryRouter *baseapp.GRPCQueryRouter, codec codec.Codec,
@@ -185,7 +185,7 @@ func convertStringToDataBytes(dataString string) (*codectypes.Any, error) {
 }
 
 // Deprecated: Supported for backward compatibility of legacy smart contracts only.
-// TODO (v7): Remove this function and all related legacy query processing functions.
+// TODO (v8): Remove this function and all related legacy query processing functions. Planned for 2026 Q4.
 func processTXChainQuery(
 	ctx sdk.Context,
 	queries txChainQuery,

--- a/x/wasm/handler/query.go
+++ b/x/wasm/handler/query.go
@@ -154,7 +154,8 @@ type txChainQuery struct {
 }
 
 // NewTXChainQueryHandler returns the tx-chain handler which handles queries from smart contracts.
-// TODO (v8): Remove the Custom query handler (processTXChainQuery) - it's deprecated for backward compatibility only. Planned for 2026 Q4.
+// TODO (v8): Remove the Custom query handler (processTXChainQuery)
+// It's deprecated for backward compatibility only. Planned for 2026 Q4.
 func NewTXChainQueryHandler(
 	assetFTQueryServer assetfttypes.QueryServer, assetNFTQueryServer assetnfttypes.QueryServer,
 	nftQueryServer nfttypes.QueryServer, gRPCQueryRouter *baseapp.GRPCQueryRouter, codec codec.Codec,


### PR DESCRIPTION
# Description

This pull request updates several deprecation comments throughout the codebase to clarify that the removal of legacy handlers and related functions is now planned for "v8" in 2026 Q4, instead of "v7". No functional or behavioral changes are introduced; only the planned removal version and date in TODO comments have been updated for clarity.

Deprecation comment updates:

* Updated all relevant TODO comments in `app/app.go`, `x/wasm/handler/message.go`, and `x/wasm/handler/query.go` to indicate that legacy message and query handlers, as well as related functions, are now scheduled for removal in v8 (2026 Q4) instead of v7. [[1]](diffhunk://#diff-0f1d2976054440336a576d47a44a37b80cdf6701dd9113012bce0e3c425819b7L748-R751) [[2]](diffhunk://#diff-f229ff78de936ddc2cade434a08d5da9cc9c4ff7a8c78e47d07860e28f63eec2L96-R96) [[3]](diffhunk://#diff-6147c146d3ceda4ff44355a78c0a274dc7e862fc6f6e12c360ebddadb2570c7eL157-R157) [[4]](diffhunk://#diff-6147c146d3ceda4ff44355a78c0a274dc7e862fc6f6e12c360ebddadb2570c7eL188-R188)

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/123)
<!-- Reviewable:end -->
