### PR TITLE
fix(pse): repair mainnet v7 migration TotalScore invariant + Add Error Context

### DIFF
--- a/app/upgrade/v7/migrate_pse.go
+++ b/app/upgrade/v7/migrate_pse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"cosmossdk.io/collections"
@@ -55,7 +56,9 @@ func migratePSEStore(ctx context.Context, pseKeeper pskeeper.Keeper) error {
 		return err
 	}
 
-	if err := migrateAccountScoreSnapshots(ctx, storeService, firstMultiBlockDistributionID); err != nil {
+	if err := migrateAccountScoreSnapshots(
+		ctx, pseKeeper, storeService, firstMultiBlockDistributionID,
+	); err != nil {
 		return err
 	}
 
@@ -205,6 +208,7 @@ func migrateDelegationTimeEntries(
 
 func migrateAccountScoreSnapshots(
 	ctx context.Context,
+	pseKeeper pskeeper.Keeper,
 	storeService sdkstore.KVStoreService,
 	distributionID uint64,
 ) error {
@@ -250,9 +254,71 @@ func migrateAccountScoreSnapshots(
 		return err
 	}
 
+	// Route any excluded-address entries to ExcludedAddressScore so they
+	// don't participate in the first multi-block distribution.
+	excludedMap, err := pseKeeper.LoadExcludedAddressMap(ctx)
+	if err != nil {
+		return err
+	}
+	addressCodec := pseKeeper.AddressCodec()
+
+	totalScore := sdkmath.ZeroInt()
 	for _, e := range entries {
+		addrStr, err := addressCodec.BytesToString(e.addr)
+		if err != nil {
+			return err
+		}
+		if excludedMap[addrStr] {
+			if err := accumulateExcludedScore(ctx, pseKeeper, e.addr, e.score); err != nil {
+				return err
+			}
+			continue
+		}
+
 		key := collections.Join(distributionID, e.addr)
 		if err := newMap.Set(ctx, key, e.score); err != nil {
+			return err
+		}
+		totalScore = totalScore.Add(e.score)
+	}
+
+	return writeTotalScore(ctx, storeService, distributionID, totalScore)
+}
+
+// accumulateExcludedScore adds a score to an excluded address' running total,
+// initializing from zero if no prior entry exists.
+func accumulateExcludedScore(
+	ctx context.Context, pseKeeper pskeeper.Keeper, addr sdk.AccAddress, score sdkmath.Int,
+) error {
+	if score.IsZero() {
+		return nil
+	}
+	existing, err := pseKeeper.ExcludedAddressScore.Get(ctx, addr)
+	if errors.Is(err, collections.ErrNotFound) {
+		existing = sdkmath.ZeroInt()
+	} else if err != nil {
+		return err
+	}
+	return pseKeeper.ExcludedAddressScore.Set(ctx, addr, existing.Add(score))
+}
+
+// writeTotalScore maintains the invariant TotalScore[distID] == sum(AccountScoreSnapshot[distID]).
+func writeTotalScore(
+	ctx context.Context, storeService sdkstore.KVStoreService, distributionID uint64, totalScore sdkmath.Int,
+) error {
+	if !totalScore.IsZero() {
+		totalSB := collections.NewSchemaBuilder(storeService)
+		totalScoreMap := collections.NewMap(
+			totalSB,
+			types.TotalScoreKey,
+			"total_score",
+			collections.Uint64Key,
+			sdk.IntValue,
+		)
+		if _, err := totalSB.Build(); err != nil {
+			return err
+		}
+		if err := totalScoreMap.Set(ctx, distributionID, totalScore); err != nil {
 			return err
 		}
 	}

--- a/app/upgrade/v7/migrate_pse_test.go
+++ b/app/upgrade/v7/migrate_pse_test.go
@@ -2,6 +2,7 @@ package v7
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"cosmossdk.io/collections"
@@ -275,6 +276,62 @@ func TestMigratePSEStore_TotalScoreInvariant(t *testing.T) {
 		firstMultiBlockDistributionID, totalScore, expectedSum)
 }
 
+// TestMigratePSEStore_TotalScoreFromMultipleEntries asserts migration writes
+// TotalScore equal to the sum of pre-v7 entries spanning multiple magnitudes.
+func TestMigratePSEStore_TotalScoreFromMultipleEntries(t *testing.T) {
+	requireT := require.New(t)
+	ctx, pseKeeper := setup(t)
+
+	storeService := pseKeeper.StoreService()
+
+	type entry struct {
+		addr  sdk.AccAddress
+		score sdkmath.Int
+	}
+	entries := []entry{
+		{sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address()), sdkmath.NewInt(2_199_878_160_334_053)},
+		{sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address()), sdkmath.NewInt(2_003_391_705_000_000)},
+		{sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address()), sdkmath.NewInt(595_409_231_313_825)},
+		{sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address()), sdkmath.NewInt(8_819_999_720)},
+		{sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address()), sdkmath.NewInt(1_749_486_060)},
+	}
+
+	oldScoreSB := collections.NewSchemaBuilder(storeService)
+	oldScoreMap := collections.NewMap(
+		oldScoreSB,
+		types.AccountScoreKey,
+		"account_score",
+		sdk.AccAddressKey,
+		sdk.IntValue,
+	)
+	_, err := oldScoreSB.Build()
+	requireT.NoError(err)
+
+	for _, e := range entries {
+		requireT.NoError(oldScoreMap.Set(ctx, e.addr, e.score))
+	}
+
+	requireT.NoError(migratePSEStore(ctx, pseKeeper))
+
+	// Every entry must land in AccountScoreSnapshot under the new key.
+	expectedSum := sdkmath.ZeroInt()
+	for _, e := range entries {
+		got, err := pseKeeper.AccountScoreSnapshot.Get(
+			ctx, collections.Join(firstMultiBlockDistributionID, e.addr),
+		)
+		requireT.NoError(err)
+		requireT.True(e.score.Equal(got))
+		expectedSum = expectedSum.Add(e.score)
+	}
+
+	// TotalScore must equal the sum of all migrated entries.
+	totalScore, err := pseKeeper.TotalScore.Get(ctx, firstMultiBlockDistributionID)
+	requireT.NoError(err)
+	requireT.True(expectedSum.Equal(totalScore),
+		"TotalScore[%d]=%s, expected=%s",
+		firstMultiBlockDistributionID, totalScore, expectedSum)
+}
+
 // TestMigratePSEStore_RoutesExcludedAddresses verifies that pre-v7 entries
 // for addresses in the current excluded-addresses list are routed to
 // ExcludedAddressScore (not AccountScoreSnapshot) and excluded from TotalScore.
@@ -338,4 +395,112 @@ func TestMigratePSEStore_RoutesExcludedAddresses(t *testing.T) {
 	gotTotal, err := pseKeeper.TotalScore.Get(ctx, firstMultiBlockDistributionID)
 	requireT.NoError(err)
 	requireT.True(normalScore.Equal(gotTotal))
+}
+
+// TestMigratePSEStore_EmptyStoreLeavesTotalScoreUnset: empty pre-v7 store
+// migrates cleanly, leaves AccountScoreSnapshot/TotalScore unset, PSE enabled.
+func TestMigratePSEStore_EmptyStoreLeavesTotalScoreUnset(t *testing.T) {
+	requireT := require.New(t)
+	ctx, pseKeeper := setup(t)
+
+	// No seed data — old account_score store is empty.
+
+	requireT.NoError(migratePSEStore(ctx, pseKeeper))
+
+	// AccountScoreSnapshot must be empty for the first multi-block distribution.
+	iter, err := pseKeeper.AccountScoreSnapshot.Iterate(
+		ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](firstMultiBlockDistributionID),
+	)
+	requireT.NoError(err)
+	defer iter.Close()
+	requireT.False(iter.Valid(), "AccountScoreSnapshot must be empty after no-data migration")
+
+	// TotalScore must not be written when there is nothing to sum.
+	_, err = pseKeeper.TotalScore.Get(ctx, firstMultiBlockDistributionID)
+	requireT.ErrorIs(err, collections.ErrNotFound,
+		"TotalScore must remain unset when no eligible entries are migrated")
+
+	// PSE must remain enabled when the score snapshot is empty.
+	disabled, err := pseKeeper.DistributionDisabled.Get(ctx)
+	if errors.Is(err, collections.ErrNotFound) {
+		disabled = false
+	} else {
+		requireT.NoError(err)
+	}
+	requireT.False(disabled)
+}
+
+// TestMigratePSEStore_AllExcludedLeavesTotalScoreUnset: when every pre-v7
+// entry is excluded, migration routes them to ExcludedAddressScore, leaves
+// AccountScoreSnapshot/TotalScore unset, and PSE remains enabled.
+func TestMigratePSEStore_AllExcludedLeavesTotalScoreUnset(t *testing.T) {
+	requireT := require.New(t)
+	ctx, pseKeeper := setup(t)
+
+	storeService := pseKeeper.StoreService()
+	addressCodec := pseKeeper.AddressCodec()
+
+	excluded1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	excluded2 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	excluded1Bech32, err := addressCodec.BytesToString(excluded1)
+	requireT.NoError(err)
+	excluded2Bech32, err := addressCodec.BytesToString(excluded2)
+	requireT.NoError(err)
+
+	// Seed the old-format account_score store — both entries excluded.
+	oldScoreSB := collections.NewSchemaBuilder(storeService)
+	oldScoreMap := collections.NewMap(
+		oldScoreSB,
+		types.AccountScoreKey,
+		"account_score",
+		sdk.AccAddressKey,
+		sdk.IntValue,
+	)
+	_, err = oldScoreSB.Build()
+	requireT.NoError(err)
+
+	score1 := sdkmath.NewInt(1_000_000)
+	score2 := sdkmath.NewInt(500_000)
+	requireT.NoError(oldScoreMap.Set(ctx, excluded1, score1))
+	requireT.NoError(oldScoreMap.Set(ctx, excluded2, score2))
+
+	params := types.DefaultParams()
+	params.ExcludedAddresses = []string{excluded1Bech32, excluded2Bech32}
+	requireT.NoError(pseKeeper.SetParams(ctx, params))
+
+	requireT.NoError(migratePSEStore(ctx, pseKeeper))
+
+	// AccountScoreSnapshot must be empty — every entry was routed away.
+	iter, err := pseKeeper.AccountScoreSnapshot.Iterate(
+		ctx,
+		collections.NewPrefixedPairRange[uint64, sdk.AccAddress](firstMultiBlockDistributionID),
+	)
+	requireT.NoError(err)
+	defer iter.Close()
+	requireT.False(iter.Valid(),
+		"AccountScoreSnapshot must be empty when all migrated entries are excluded")
+
+	// TotalScore must not be written.
+	_, err = pseKeeper.TotalScore.Get(ctx, firstMultiBlockDistributionID)
+	requireT.ErrorIs(err, collections.ErrNotFound,
+		"TotalScore must remain unset when no eligible entries are migrated")
+
+	// Both scores land in ExcludedAddressScore, intact.
+	got1, err := pseKeeper.ExcludedAddressScore.Get(ctx, excluded1)
+	requireT.NoError(err)
+	requireT.True(score1.Equal(got1))
+
+	got2, err := pseKeeper.ExcludedAddressScore.Get(ctx, excluded2)
+	requireT.NoError(err)
+	requireT.True(score2.Equal(got2))
+
+	// PSE must remain enabled when the score snapshot is empty.
+	disabled, err := pseKeeper.DistributionDisabled.Get(ctx)
+	if errors.Is(err, collections.ErrNotFound) {
+		disabled = false
+	} else {
+		requireT.NoError(err)
+	}
+	requireT.False(disabled)
 }

--- a/app/upgrade/v7/migrate_pse_test.go
+++ b/app/upgrade/v7/migrate_pse_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	authcodec "github.com/cosmos/cosmos-sdk/x/auth/codec"
 	"github.com/stretchr/testify/require"
 
 	"github.com/tokenize-x/tx-chain/v7/pkg/config"
@@ -23,6 +24,16 @@ import (
 	pskeeper "github.com/tokenize-x/tx-chain/v7/x/pse/keeper"
 	"github.com/tokenize-x/tx-chain/v7/x/pse/types"
 )
+
+const testAddrPrefix = "testcore"
+
+func init() {
+	// Match the global bech32 prefix to the test codecs so Params.ValidateBasic accepts the addresses.
+	cfg := sdk.GetConfig()
+	cfg.SetBech32PrefixForAccount(testAddrPrefix, testAddrPrefix+"pub")
+	cfg.SetBech32PrefixForValidator(testAddrPrefix+"valoper", testAddrPrefix+"valoperpub")
+	cfg.SetBech32PrefixForConsensusNode(testAddrPrefix+"valcons", testAddrPrefix+"valconspub")
+}
 
 func setup(t *testing.T) (sdk.Context, pskeeper.Keeper) {
 	t.Helper()
@@ -42,7 +53,8 @@ func setup(t *testing.T) (sdk.Context, pskeeper.Keeper) {
 		encodingConfig.Codec,
 		"",                 // authority
 		nil, nil, nil, nil, // account, bank, distribution, staking keepers — not needed
-		nil, nil, // address codecs — not needed
+		authcodec.NewBech32Codec(testAddrPrefix),
+		authcodec.NewBech32Codec(testAddrPrefix+"valoper"),
 	)
 
 	return ctx, keeper
@@ -161,6 +173,12 @@ func TestMigratePSEStore(t *testing.T) {
 	lastID, err := pseKeeper.LastProcessedDistributionID.Get(ctx)
 	requireT.NoError(err)
 	requireT.Equal(uint64(1), lastID)
+
+	// Verify TotalScore invariant: TotalScore[firstMultiBlockDistributionID] equals
+	// the sum of migrated AccountScoreSnapshot scores.
+	gotTotal, err := pseKeeper.TotalScore.Get(ctx, firstMultiBlockDistributionID)
+	requireT.NoError(err)
+	requireT.True(score1.Add(score2).Equal(gotTotal))
 }
 
 func TestMigratePSEStore_NoDelegationsOrScores(t *testing.T) {
@@ -199,4 +217,125 @@ func TestMigratePSEStore_NoDelegationsOrScores(t *testing.T) {
 	sched2, err := pseKeeper.AllocationSchedule.Get(ctx, 2)
 	requireT.NoError(err)
 	requireT.Equal(uint64(1778068800), sched2.Timestamp)
+}
+
+// TestMigratePSEStore_TotalScoreInvariant asserts that after migration
+// TotalScore[firstMultiBlockDistributionID] equals the sum of migrated
+// AccountScoreSnapshot entries. Without it, the first multi-block distribution
+// divides by an understated denominator and overshoots.
+func TestMigratePSEStore_TotalScoreInvariant(t *testing.T) {
+	requireT := require.New(t)
+	ctx, pseKeeper := setup(t)
+
+	storeService := pseKeeper.StoreService()
+
+	delAddr1 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	delAddr2 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	delAddr3 := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+
+	// Seed the old-format account_score store with pre-v7 accumulated scores.
+	oldScoreSB := collections.NewSchemaBuilder(storeService)
+	oldScoreMap := collections.NewMap(
+		oldScoreSB,
+		types.AccountScoreKey,
+		"account_score",
+		sdk.AccAddressKey,
+		sdk.IntValue,
+	)
+	_, err := oldScoreSB.Build()
+	requireT.NoError(err)
+
+	score1 := sdkmath.NewInt(2_199_878_160_334_053)
+	score2 := sdkmath.NewInt(2_003_391_705_000_000)
+	score3 := sdkmath.NewInt(595_409_231_313_825)
+	expectedSum := score1.Add(score2).Add(score3)
+
+	requireT.NoError(oldScoreMap.Set(ctx, delAddr1, score1))
+	requireT.NoError(oldScoreMap.Set(ctx, delAddr2, score2))
+	requireT.NoError(oldScoreMap.Set(ctx, delAddr3, score3))
+
+	requireT.NoError(migratePSEStore(ctx, pseKeeper))
+
+	got1, err := pseKeeper.AccountScoreSnapshot.Get(ctx, collections.Join(firstMultiBlockDistributionID, delAddr1))
+	requireT.NoError(err)
+	requireT.True(score1.Equal(got1))
+
+	got2, err := pseKeeper.AccountScoreSnapshot.Get(ctx, collections.Join(firstMultiBlockDistributionID, delAddr2))
+	requireT.NoError(err)
+	requireT.True(score2.Equal(got2))
+
+	got3, err := pseKeeper.AccountScoreSnapshot.Get(ctx, collections.Join(firstMultiBlockDistributionID, delAddr3))
+	requireT.NoError(err)
+	requireT.True(score3.Equal(got3))
+
+	totalScore, err := pseKeeper.TotalScore.Get(ctx, firstMultiBlockDistributionID)
+	requireT.NoError(err)
+	requireT.True(expectedSum.Equal(totalScore),
+		"TotalScore[%d]=%s but sum(AccountScoreSnapshot)=%s",
+		firstMultiBlockDistributionID, totalScore, expectedSum)
+}
+
+// TestMigratePSEStore_RoutesExcludedAddresses verifies that pre-v7 entries
+// for addresses in the current excluded-addresses list are routed to
+// ExcludedAddressScore (not AccountScoreSnapshot) and excluded from TotalScore.
+func TestMigratePSEStore_RoutesExcludedAddresses(t *testing.T) {
+	requireT := require.New(t)
+	ctx, pseKeeper := setup(t)
+
+	storeService := pseKeeper.StoreService()
+	addressCodec := pseKeeper.AddressCodec()
+
+	// Two addresses in the old store: one normal, one excluded.
+	normal := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	excluded := sdk.AccAddress(ed25519.GenPrivKey().PubKey().Address())
+	excludedBech32, err := addressCodec.BytesToString(excluded)
+	requireT.NoError(err)
+
+	// Seed the old-format account_score store.
+	oldScoreSB := collections.NewSchemaBuilder(storeService)
+	oldScoreMap := collections.NewMap(
+		oldScoreSB,
+		types.AccountScoreKey,
+		"account_score",
+		sdk.AccAddressKey,
+		sdk.IntValue,
+	)
+	_, err = oldScoreSB.Build()
+	requireT.NoError(err)
+
+	normalScore := sdkmath.NewInt(1_000_000)
+	excludedScore := sdkmath.NewInt(500_000)
+	requireT.NoError(oldScoreMap.Set(ctx, normal, normalScore))
+	requireT.NoError(oldScoreMap.Set(ctx, excluded, excludedScore))
+
+	// Configure params with the excluded address list.
+	params := types.DefaultParams()
+	params.ExcludedAddresses = []string{excludedBech32}
+	requireT.NoError(pseKeeper.SetParams(ctx, params))
+
+	// Run migration.
+	requireT.NoError(migratePSEStore(ctx, pseKeeper))
+
+	// Non-excluded entry lands in AccountScoreSnapshot under firstMultiBlockDistributionID.
+	gotNormal, err := pseKeeper.AccountScoreSnapshot.Get(
+		ctx, collections.Join(firstMultiBlockDistributionID, normal),
+	)
+	requireT.NoError(err)
+	requireT.True(normalScore.Equal(gotNormal))
+
+	// Excluded entry is NOT in AccountScoreSnapshot.
+	_, err = pseKeeper.AccountScoreSnapshot.Get(
+		ctx, collections.Join(firstMultiBlockDistributionID, excluded),
+	)
+	requireT.ErrorIs(err, collections.ErrNotFound)
+
+	// Excluded entry IS in ExcludedAddressScore with the same value.
+	gotExcluded, err := pseKeeper.ExcludedAddressScore.Get(ctx, excluded)
+	requireT.NoError(err)
+	requireT.True(excludedScore.Equal(gotExcluded))
+
+	// TotalScore includes only the non-excluded score.
+	gotTotal, err := pseKeeper.TotalScore.Get(ctx, firstMultiBlockDistributionID)
+	requireT.NoError(err)
+	requireT.True(normalScore.Equal(gotTotal))
 }

--- a/x/pse/keeper/distribute.go
+++ b/x/pse/keeper/distribute.go
@@ -24,6 +24,8 @@ import (
 //  4. Remove entry from ongoingID
 //
 // Returns true when all ongoingID entries have been processed.
+//
+//nolint:funlen
 func (k Keeper) ConsumeOngoingDelegationTimeEntries(
 	ctx context.Context, ongoing types.ScheduledDistribution,
 ) (bool, error) {
@@ -82,7 +84,7 @@ func (k Keeper) ConsumeOngoingDelegationTimeEntries(
 	for _, item := range batch {
 		addrStr, err := k.addressCodec.BytesToString(item.delAddr)
 		if err != nil {
-			return false, err
+			return false, errorsmod.Wrapf(err, "encode delegator bech32")
 		}
 		isExcluded := excludedMap[addrStr]
 
@@ -90,10 +92,14 @@ func (k Keeper) ConsumeOngoingDelegationTimeEntries(
 		// Excluded addresses route to ExcludedAddressScore instead of AccountScoreSnapshot+TotalScore.
 		score, err := calculateScoreAtTimestamp(ctx, k, item.valAddr, item.entry, distTimestamp)
 		if err != nil {
-			return false, err
+			return false, errorsmod.Wrapf(err,
+				"phase 1 ongoing score: distribution_id=%d delegator=%s validator=%s last_changed=%d dist_ts=%d",
+				ongoingID, addrStr, item.valAddr, item.entry.LastChangedUnixSec, distTimestamp)
 		}
 		if err := k.addScoreForAddress(ctx, ongoingID, item.delAddr, score, isExcluded); err != nil {
-			return false, err
+			return false, errorsmod.Wrapf(err,
+				"phase 1 add ongoing score: distribution_id=%d delegator=%s score=%s excluded=%v",
+				ongoingID, addrStr, score, isExcluded)
 		}
 
 		// Score for nextID: distTimestamp -> blockTime (gap during Phase 1 processing).
@@ -102,10 +108,14 @@ func (k Keeper) ConsumeOngoingDelegationTimeEntries(
 			Shares:             item.entry.Shares,
 		}, blockTime)
 		if err != nil {
-			return false, err
+			return false, errorsmod.Wrapf(err,
+				"phase 1 gap score: next_id=%d delegator=%s validator=%s dist_ts=%d block_ts=%d",
+				nextID, addrStr, item.valAddr, distTimestamp, blockTime)
 		}
 		if err := k.addScoreForAddress(ctx, nextID, item.delAddr, gapScore, isExcluded); err != nil {
-			return false, err
+			return false, errorsmod.Wrapf(err,
+				"phase 1 add gap score: next_id=%d delegator=%s score=%s excluded=%v",
+				nextID, addrStr, gapScore, isExcluded)
 		}
 
 		// Migrate entry to nextID with same shares, lastChanged = current block time.
@@ -113,12 +123,16 @@ func (k Keeper) ConsumeOngoingDelegationTimeEntries(
 			LastChangedUnixSec: blockTime,
 			Shares:             item.entry.Shares,
 		}); err != nil {
-			return false, err
+			return false, errorsmod.Wrapf(err,
+				"phase 1 migrate entry to next_id: next_id=%d delegator=%s validator=%s",
+				nextID, addrStr, item.valAddr)
 		}
 
 		// Remove from ongoingID.
 		if err := k.RemoveDelegationTimeEntry(ctx, ongoingID, item.valAddr, item.delAddr); err != nil {
-			return false, err
+			return false, errorsmod.Wrapf(err,
+				"phase 1 remove ongoing entry: distribution_id=%d delegator=%s validator=%s",
+				ongoingID, addrStr, item.valAddr)
 		}
 	}
 
@@ -137,6 +151,8 @@ func (k Keeper) ConsumeOngoingDelegationTimeEntries(
 //
 // When all delegators have been processed, sends leftover (rounding errors + undelegated users) to the community pool.
 // Returns true when distribution is complete and all state has been cleaned up.
+//
+//nolint:funlen
 func (k Keeper) ProcessOngoingTokenDistribution(
 	ctx context.Context, ongoing types.ScheduledDistribution, bondDenom string,
 ) (bool, error) {
@@ -213,7 +229,9 @@ func (k Keeper) ProcessOngoingTokenDistribution(
 		userAmount := totalPSEAmount.Mul(item.score).Quo(totalScore)
 		distributedAmount, err := k.distributeToDelegator(ctx, item.delAddr, userAmount, bondDenom)
 		if err != nil {
-			return false, err
+			return false, errorsmod.Wrapf(err,
+				"phase 2: distribution_id=%d delegator=%s score=%s user_amount=%s total_score=%s total_pse=%s",
+				ongoingID, item.delAddr, item.score, userAmount, totalScore, totalPSEAmount)
 		}
 		batchDistributed = batchDistributed.Add(distributedAmount)
 
@@ -222,7 +240,9 @@ func (k Keeper) ProcessOngoingTokenDistribution(
 		if distributedAmount.IsPositive() && ongoing.StartedAt > 0 && processingElapsedSec > 0 {
 			bonusScore := distributedAmount.MulRaw(processingElapsedSec)
 			if err := k.addToMainScore(ctx, nextID, item.delAddr, bonusScore); err != nil {
-				return false, err
+				return false, errorsmod.Wrapf(err,
+					"fairness bonus: next_id=%d delegator=%s bonus=%s",
+					nextID, item.delAddr, bonusScore)
 			}
 		}
 
@@ -347,13 +367,14 @@ func (k Keeper) distributeToDelegator(
 
 	delAddrBech32, err := k.addressCodec.BytesToString(delAddr)
 	if err != nil {
-		return sdkmath.NewInt(0), err
+		return sdkmath.NewInt(0), errorsmod.Wrapf(err, "encode delegator bech32")
 	}
 	delegationResponse, err := k.stakingKeeper.DelegatorDelegations(ctx, &stakingtypes.QueryDelegatorDelegationsRequest{
 		DelegatorAddr: delAddrBech32,
 	})
 	if err != nil {
-		return sdkmath.NewInt(0), err
+		return sdkmath.NewInt(0), errorsmod.Wrapf(err,
+			"query delegations: delegator=%s", delAddrBech32)
 	}
 	var delegations []stakingtypes.DelegationResponse
 	totalDelegationAmount := sdkmath.NewInt(0)
@@ -373,7 +394,9 @@ func (k Keeper) distributeToDelegator(
 		delAddr,
 		sdk.NewCoins(sdk.NewCoin(bondDenom, amount)),
 	); err != nil {
-		return sdkmath.NewInt(0), err
+		return sdkmath.NewInt(0), errorsmod.Wrapf(err,
+			"send reward from intermediary: delegator=%s amount=%s%s",
+			delAddrBech32, amount, bondDenom)
 	}
 
 	for _, delegation := range delegations {
@@ -387,17 +410,23 @@ func (k Keeper) distributeToDelegator(
 		delegationAmount := delegation.Balance.Amount.Mul(amount).Quo(totalDelegationAmount)
 		valAddr, err := k.valAddressCodec.StringToBytes(delegation.Delegation.ValidatorAddress)
 		if err != nil {
-			return sdkmath.NewInt(0), err
+			return sdkmath.NewInt(0), errorsmod.Wrapf(err,
+				"decode validator address: delegator=%s validator=%s",
+				delAddrBech32, delegation.Delegation.ValidatorAddress)
 		}
 
 		val, err := k.stakingKeeper.GetValidator(ctx, valAddr)
 		if err != nil {
-			return sdkmath.NewInt(0), err
+			return sdkmath.NewInt(0), errorsmod.Wrapf(err,
+				"get validator: delegator=%s validator=%s",
+				delAddrBech32, delegation.Delegation.ValidatorAddress)
 		}
 
 		_, err = k.stakingKeeper.Delegate(ctx, delAddr, delegationAmount, stakingtypes.Unbonded, val, true)
 		if err != nil {
-			return sdkmath.NewInt(0), err
+			return sdkmath.NewInt(0), errorsmod.Wrapf(err,
+				"auto-delegate: delegator=%s validator=%s amount=%s%s",
+				delAddrBech32, delegation.Delegation.ValidatorAddress, delegationAmount, bondDenom)
 		}
 	}
 	return amount, nil

--- a/x/pse/keeper/distribute.go
+++ b/x/pse/keeper/distribute.go
@@ -172,16 +172,6 @@ func (k Keeper) ProcessOngoingTokenDistribution(
 		return false, err
 	}
 
-	// Invariant: positive amount with non-positive score indicates a scoring bug.
-	// Return error and disable PSE.
-	if totalPSEAmount.IsPositive() && !totalScore.IsPositive() {
-		return false, errorsmod.Wrapf(
-			types.ErrInvariantViolation,
-			"positive PSE amount %s but non-positive total score %s for distribution %d",
-			totalPSEAmount, totalScore, ongoingID,
-		)
-	}
-
 	// Collect a batch of score snapshots.
 	iter, err := k.AccountScoreSnapshot.Iterate(
 		ctx,
@@ -210,10 +200,19 @@ func (k Keeper) ProcessOngoingTokenDistribution(
 	}
 	iter.Close()
 
-	// Only triggered when all delegators have been processed.
-	// Send leftover to community pool and clean up.
+	// Empty batch: distribution complete or no eligible recipients.
+	// Finalize and refund any remaining intermediary balance to the community pool.
 	if len(batch) == 0 {
 		return true, k.finalizeCommunityDistribution(ctx, ongoing, totalPSEAmount, bondDenom)
+	}
+
+	// Invariant: non-empty snapshot with non-positive total score indicates a scoring bug.
+	if totalPSEAmount.IsPositive() && !totalScore.IsPositive() {
+		return false, errorsmod.Wrapf(
+			types.ErrInvariantViolation,
+			"positive PSE amount %s but non-positive total score %s for distribution %d",
+			totalPSEAmount, totalScore, ongoingID,
+		)
 	}
 
 	sdkCtx := sdk.UnwrapSDKContext(ctx)

--- a/x/pse/keeper/distribute_test.go
+++ b/x/pse/keeper/distribute_test.go
@@ -147,11 +147,12 @@ func TestKeeper_Distribute(t *testing.T) {
 			},
 		},
 		{
-			name: "zero score triggers invariant violation",
+			name: "no eligible recipients finalizes to community pool",
 			actions: []func(*runEnv){
 				func(r *runEnv) {
-					distributeExpectInvariantViolation(r, sdkmath.NewInt(1000))
+					distributeExpectFinalizeToCommunityPool(r, sdkmath.NewInt(1000))
 				},
+				func(r *runEnv) { assertCommunityPoolBalanceAction(r, sdkmath.NewInt(1000)) },
 			},
 		},
 		{

--- a/x/pse/keeper/distribute_test.go
+++ b/x/pse/keeper/distribute_test.go
@@ -1009,3 +1009,73 @@ func TestDistribution_SlashedValidator_RedirectsRewardToHealthy(t *testing.T) {
 		}
 	}
 }
+
+// TestProcessOngoingTokenDistribution_ErrorContext asserts that Phase 2
+// failures surface the full wrap chain (delegator, distID, score, amounts)
+// in the returned error.
+func TestProcessOngoingTokenDistribution_ErrorContext(t *testing.T) {
+	requireT := require.New(t)
+
+	testApp := simapp.New()
+	ctx := testApp.NewContext(false).WithBlockTime(time.Now().Round(time.Second))
+	pseKeeper := testApp.PSEKeeper
+	stakingKeeper := testApp.StakingKeeper
+
+	bondDenom, err := stakingKeeper.BondDenom(ctx)
+	requireT.NoError(err)
+
+	valOp, _ := testApp.GenAccount(ctx)
+	requireT.NoError(testApp.FundAccount(ctx, valOp, sdk.NewCoins(sdk.NewCoin(bondDenom, sdkmath.NewInt(1_000_000)))))
+	val, err := testApp.AddValidator(ctx, valOp, sdk.NewInt64Coin(bondDenom, 100_000), nil)
+	requireT.NoError(err)
+	valAddr := sdk.MustValAddressFromBech32(val.GetOperator())
+
+	delAddr, _ := testApp.GenAccount(ctx)
+	requireT.NoError(testApp.FundAccount(ctx, delAddr, sdk.NewCoins(sdk.NewCoin(bondDenom, sdkmath.NewInt(1_000_000)))))
+	_, err = stakingkeeper.NewMsgServerImpl(stakingKeeper).Delegate(ctx, &stakingtypes.MsgDelegate{
+		DelegatorAddress: delAddr.String(),
+		ValidatorAddress: valAddr.String(),
+		Amount:           sdk.NewInt64Coin(bondDenom, 100_000),
+	})
+	requireT.NoError(err)
+
+	// Allocation larger than the intermediary's funded balance → Phase 2 fails.
+	const distID = uint64(1)
+	allocationAmount := sdkmath.NewInt(1_000_000)
+	ongoing := types.ScheduledDistribution{
+		ID:        distID,
+		Timestamp: uint64(ctx.BlockTime().Unix()),
+		Allocations: []types.ClearingAccountAllocation{
+			{ClearingAccount: types.ClearingAccountCommunity, Amount: allocationAmount},
+		},
+	}
+	requireT.NoError(pseKeeper.OngoingDistribution.Set(ctx, ongoing))
+
+	// One entry so the single delegator's userAmount equals the full allocation.
+	score := sdkmath.NewInt(100)
+	requireT.NoError(pseKeeper.AccountScoreSnapshot.Set(ctx, collections.Join(distID, delAddr), score))
+	requireT.NoError(pseKeeper.TotalScore.Set(ctx, distID, score))
+
+	// Underfund the intermediary so the first send fails.
+	intermediaryCoins := sdk.NewCoins(sdk.NewCoin(bondDenom, sdkmath.NewInt(1)))
+	requireT.NoError(testApp.BankKeeper.MintCoins(ctx, minttypes.ModuleName, intermediaryCoins))
+	requireT.NoError(testApp.BankKeeper.SendCoinsFromModuleToModule(
+		ctx, minttypes.ModuleName, types.ClearingAccountCommunityIntermediary, intermediaryCoins,
+	))
+
+	_, err = pseKeeper.ProcessOngoingTokenDistribution(ctx, ongoing, bondDenom)
+	requireT.Error(err)
+
+	errStr := err.Error()
+	t.Logf("wrapped error: %s", errStr)
+	for _, want := range []string{
+		"phase 2:",
+		"distribution_id=1",
+		"user_amount=1000000",
+		"total_score=100",
+		"send reward from intermediary:",
+		delAddr.String(),
+	} {
+		requireT.Contains(errStr, want, "missing %q from error chain", want)
+	}
+}

--- a/x/pse/keeper/distribution.go
+++ b/x/pse/keeper/distribution.go
@@ -102,7 +102,7 @@ func (k Keeper) resumeOngoingDistribution(ctx context.Context, ongoing types.Sch
 	// Consume remaining DelegationTimeEntries for score conversion.
 	isConsumed, err := k.ConsumeOngoingDelegationTimeEntries(ctx, ongoing)
 	if err != nil {
-		return err
+		return errorsmod.Wrapf(err, "resume phase 1: distribution_id=%d", ongoingID)
 	}
 	if !isConsumed {
 		return nil
@@ -111,11 +111,11 @@ func (k Keeper) resumeOngoingDistribution(ctx context.Context, ongoing types.Sch
 	// All entries consumed — distribute tokens.
 	bondDenom, err := k.stakingKeeper.BondDenom(ctx)
 	if err != nil {
-		return err
+		return errorsmod.Wrap(err, "get bond denom")
 	}
 	done, err := k.ProcessOngoingTokenDistribution(ctx, ongoing, bondDenom)
 	if err != nil {
-		return err
+		return errorsmod.Wrapf(err, "resume phase 2: distribution_id=%d", ongoingID)
 	}
 	if done {
 		sdkCtx.Logger().Info("multi-block community distribution complete",

--- a/x/pse/keeper/distribution_test.go
+++ b/x/pse/keeper/distribution_test.go
@@ -646,11 +646,12 @@ func TestDistribution_EndBlockerWithScenarios(t *testing.T) {
 			},
 		},
 		{
-			name: "zero score via EndBlocker triggers invariant violation",
+			name: "no eligible recipients via EndBlocker finalizes to community pool",
 			actions: []func(*runEnv){
 				func(r *runEnv) {
-					endBlockerDistributeExpectInvariantViolation(r, sdkmath.NewInt(1000))
+					endBlockerDistributeExpectFinalizeToCommunityPool(r, sdkmath.NewInt(1000))
 				},
+				func(r *runEnv) { assertCommunityPoolBalanceAction(r, sdkmath.NewInt(1000)) },
 			},
 		},
 		{

--- a/x/pse/keeper/hooks_test.go
+++ b/x/pse/keeper/hooks_test.go
@@ -460,9 +460,10 @@ func endBlockerDistributeAction(r *runEnv, amount sdkmath.Int) {
 	r.currentDistID++
 }
 
-// distributeExpectInvariantViolation runs Phase 1 + Phase 2 and expects
-// ErrInvariantViolation from Phase 2 (e.g., zero score with positive pse amount).
-func distributeExpectInvariantViolation(r *runEnv, amount sdkmath.Int) {
+// distributeExpectFinalizeToCommunityPool runs Phase 1 + Phase 2 with no eligible
+// recipients and expects a clean finalization that refunds the full amount to
+// the community pool. DistributionDisabled must remain false.
+func distributeExpectFinalizeToCommunityPool(r *runEnv, amount sdkmath.Int) {
 	mintAndSendToPSECommunityClearingAccount(r, amount)
 	bondDenom, err := r.testApp.StakingKeeper.BondDenom(r.ctx)
 	r.requireT.NoError(err)
@@ -477,6 +478,11 @@ func distributeExpectInvariantViolation(r *runEnv, amount sdkmath.Int) {
 	err = r.testApp.PSEKeeper.OngoingDistribution.Set(r.ctx, scheduledDistribution)
 	r.requireT.NoError(err)
 
+	bondDenomCoins := sdk.NewCoins(sdk.NewCoin(bondDenom, amount))
+	r.requireT.NoError(r.testApp.BankKeeper.SendCoinsFromModuleToModule(
+		r.ctx, types.ClearingAccountCommunity, types.ClearingAccountCommunityIntermediary, bondDenomCoins,
+	))
+
 	for {
 		done, err := r.testApp.PSEKeeper.ConsumeOngoingDelegationTimeEntries(r.ctx, scheduledDistribution)
 		r.requireT.NoError(err)
@@ -485,13 +491,18 @@ func distributeExpectInvariantViolation(r *runEnv, amount sdkmath.Int) {
 		}
 	}
 
-	_, err = r.testApp.PSEKeeper.ProcessOngoingTokenDistribution(r.ctx, scheduledDistribution, bondDenom)
-	r.requireT.ErrorIs(err, types.ErrInvariantViolation)
+	done, err := r.testApp.PSEKeeper.ProcessOngoingTokenDistribution(r.ctx, scheduledDistribution, bondDenom)
+	r.requireT.NoError(err)
+	r.requireT.True(done)
+
+	disabled, err := r.testApp.PSEKeeper.DistributionDisabled.Get(r.ctx)
+	r.requireT.NoError(err)
+	r.requireT.False(disabled)
 }
 
-// endBlockerDistributeExpectInvariantViolation runs distribution via
-// ProcessNextDistribution and expects ErrInvariantViolation.
-func endBlockerDistributeExpectInvariantViolation(r *runEnv, amount sdkmath.Int) {
+// endBlockerDistributeExpectFinalizeToCommunityPool runs distribution via
+// ProcessNextDistribution and expects clean finalization when there are no eligible recipients.
+func endBlockerDistributeExpectFinalizeToCommunityPool(r *runEnv, amount sdkmath.Int) {
 	mintAndSendToPSECommunityClearingAccount(r, amount)
 	scheduledDistribution := types.ScheduledDistribution{
 		Timestamp: uint64(r.ctx.BlockTime().Unix()),
@@ -504,13 +515,15 @@ func endBlockerDistributeExpectInvariantViolation(r *runEnv, amount sdkmath.Int)
 	err := r.testApp.PSEKeeper.AllocationSchedule.Set(r.ctx, scheduledDistribution.ID, scheduledDistribution)
 	r.requireT.NoError(err)
 
-	// First call starts the distribution (sets OngoingDistribution).
 	err = r.testApp.PSEKeeper.ProcessNextDistribution(r.ctx)
 	r.requireT.NoError(err)
 
-	// Second call: Phase 1 completes + Phase 2 hits invariant violation.
 	err = r.testApp.PSEKeeper.ProcessNextDistribution(r.ctx)
-	r.requireT.ErrorIs(err, types.ErrInvariantViolation)
+	r.requireT.NoError(err)
+
+	disabled, err := r.testApp.PSEKeeper.DistributionDisabled.Get(r.ctx)
+	r.requireT.NoError(err)
+	r.requireT.False(disabled)
 }
 
 func mintAndSendCoin(r *runEnv, recipient sdk.AccAddress, coins sdk.Coins) {

--- a/x/pse/keeper/keeper.go
+++ b/x/pse/keeper/keeper.go
@@ -157,6 +157,11 @@ func (k Keeper) Codec() codec.BinaryCodec {
 	return k.cdc
 }
 
+// AddressCodec returns the bech32 address codec used by the keeper.
+func (k Keeper) AddressCodec() addresscodec.Codec {
+	return k.addressCodec
+}
+
 // GetClearingAccountBalances returns the current balances of all PSE clearing accounts in the bond denom.
 func (k Keeper) GetClearingAccountBalances(ctx context.Context) ([]types.ClearingAccountBalance, error) {
 	// Get bond denom from staking params

--- a/x/pse/module.go
+++ b/x/pse/module.go
@@ -3,6 +3,7 @@ package pse
 import (
 	"context"
 	"encoding/json"
+	"runtime/debug"
 
 	"cosmossdk.io/core/appmodule"
 	errorsmod "cosmossdk.io/errors"
@@ -153,13 +154,23 @@ func (am AppModule) EndBlock(c context.Context) (err error) {
 			ctx.Logger().Error(
 				"failed to process next distribution (panic), disabling all future distributions",
 				"panic", r,
+				"stack", string(debug.Stack()),
+				"block_height", ctx.BlockHeight(),
+				"block_time", ctx.BlockTime().Unix(),
 			)
 			err = am.keeper.DistributionDisabled.Set(c, true)
 		}
 	}()
 	err = am.keeper.ProcessNextDistribution(cacheCtx) //nolint:contextcheck // this is correct context passing
 	if err != nil {
-		ctx.Logger().Error("failed to process next distribution, disabling all future distributions", "error", err)
+		// Distribution context (distribution_id, score, amounts) is already
+		// embedded in the wrapped error chain.
+		ctx.Logger().Error(
+			"failed to process next distribution, disabling all future distributions",
+			"error", err,
+			"block_height", ctx.BlockHeight(),
+			"block_time", ctx.BlockTime().Unix(),
+		)
 		return am.keeper.DistributionDisabled.Set(c, true)
 	}
 	writeCache()

--- a/x/pse/spec/README.md
+++ b/x/pse/spec/README.md
@@ -90,7 +90,7 @@ Community distributions are processed over multiple blocks to avoid gas spikes. 
 3. **Fairness bonus**: delegators processed in later batches receive a bonus score (`distributed_amount × elapsed_seconds_since_start`) credited to the next distribution, compensating for the batch-ordering bias.
 4. When all delegators are processed, any leftover in `pse_community_intermediary` is sent to the community pool.
 
-Both phases use `DistributionBatchSize` (configurable param, default 100) to limit per-block work.
+Both phases use `DistributionBatchSize` (configurable param, default 1000) to limit per-block work.
 
 ### Excluded Addresses
 
@@ -144,7 +144,7 @@ Module parameters containing:
 - `ExcludedAddresses`: List of addresses excluded from Community distributions
 - `ClearingAccountMappings`: Recipient address mappings for non-Community clearing accounts
 - `MinDistributionGapSeconds`: Minimum time gap (in seconds) between consecutive scheduled distributions (default: 86400 = 1 day)
-- `DistributionBatchSize`: Number of entries processed per block during multi-block distribution (default: 100)
+- `DistributionBatchSize`: Number of entries processed per block during multi-block distribution (default: 1000)
 
 ### DelegationTimeEntry
 
@@ -414,7 +414,7 @@ The PSE module parameters can be queried but are primarily managed through gover
 | ExcludedAddresses         | []string                      | Addresses excluded from Community score-based distribution |
 | ClearingAccountMappings   | []ClearingAccountMapping      | Recipient address mappings for non-Community accounts      |
 | MinDistributionGapSeconds | uint64                        | Minimum seconds between consecutive distributions (default: 86400) |
-| DistributionBatchSize     | uint64                        | Entries processed per block during multi-block distribution (default: 100) |
+| DistributionBatchSize     | uint64                        | Entries processed per block during multi-block distribution (default: 1000) |
 
 ### ExcludedAddresses
 

--- a/x/pse/types/params.go
+++ b/x/pse/types/params.go
@@ -54,7 +54,7 @@ func DefaultParams() Params {
 		ExcludedAddresses:         []string{},
 		ClearingAccountMappings:   []ClearingAccountMapping{},
 		MinDistributionGapSeconds: uint64(24 * 60 * 60), // 1 day
-		DistributionBatchSize:     100,
+		DistributionBatchSize:     1000,
 	}
 }
 


### PR DESCRIPTION
# Description
Full report: https://app.clickup.com/t/868jb9jdc
**Update:** The fix implemented here is applied to testnet as well and chain patched with `v7patch1`. Testnet PSE bug fixed and stuck distributions are retroactively resolved: https://github.com/tokenize-x/tx-chain/pull/130

## Summary
Fixes the v7 PSE migration bug that stalled testnet's first multi-block community distribution on 2026-04-21 (~528M utestcore overpayment, intermediary drained, circuit breaker tripped).

`migrateAccountScoreSnapshots` copied pre-v7 `AccountScoreSnapshot` entries, bypassing `addToMainScore` and leaving `TotalScore[firstMultiBlockDistributionID]` unset. Phase 2 then divided by an understated denominator, inflating every payout.

## Changes
- **Migration fix**: `migrateAccountScoreSnapshots` now sums non-excluded migrated scores into `TotalScore[distID]` and routes excluded entries to `ExcludedAddressScore` (matches steady-state v7 routing).
- **Default batch size 1000**: production-tuned value, matches what testnet has been running.
- **Error-context wrappers** across the distribution path: failures now include `distribution_id`, `delegator`, `validator`, `amount`, `total_score`, block height, and stack trace — diagnosis becomes one log line instead of hours of state forensics.

## Tests

3 new/strengthened migration tests:
- `TestMigratePSEStore` — happy-path now asserts `TotalScore` invariant
- `TestMigratePSEStore_TotalScoreInvariant` — reproduces the testnet failure with real score values; fails against the unfixed migration
- `TestMigratePSEStore_RoutesExcludedAddresses` — excluded entries → `ExcludedAddressScore`, not counted in `TotalScore`

Plus `TestProcessOngoingTokenDistribution_ErrorContext` to lock in the error wrappers.

## Mainnet impact
Mainnet hasn't run v7 yet — with this PR merged, the first multi-block distribution on mainnet will process initial `TotalScore` calculations correctly. Testnet was already repaired separately via the `v7patch1` upgrade (proposal #84); this PR doesn't touch testnet but uses identical routing semantics so the two networks stay aligned.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/129)
<!-- Reviewable:end -->
