### PR TITLE
Fix Randomness in Funding acccounts in integration tests

### DIFF
--- a/testutil/integration/faucet.go
+++ b/testutil/integration/faucet.go
@@ -160,14 +160,26 @@ func (f Faucet) collectRequests(ctx context.Context, leaderReq fundingRequest) (
 func (f Faucet) prepareMultiSendMessage(requests []fundingRequest) *banktypes.MsgMultiSend {
 	msg := &banktypes.MsgMultiSend{}
 	sum := sdk.NewCoins()
+	outputsByAddress := map[string]sdk.Coins{}
+	addressOrder := make([]string, 0)
 	for _, r := range requests {
 		for _, a := range r.AccountsToFund {
 			sum = sum.Add(a.Amount)
-			msg.Outputs = append(msg.Outputs, banktypes.Output{
-				Address: f.chainCtx.MustConvertToBech32Address(a.Address),
-				Coins:   sdk.NewCoins(a.Amount),
-			})
+			address := f.chainCtx.MustConvertToBech32Address(a.Address)
+			coins := sdk.NewCoins(a.Amount)
+			if existing, ok := outputsByAddress[address]; ok {
+				outputsByAddress[address] = existing.Add(coins...)
+				continue
+			}
+			outputsByAddress[address] = coins
+			addressOrder = append(addressOrder, address)
 		}
+	}
+	for _, address := range addressOrder {
+		msg.Outputs = append(msg.Outputs, banktypes.Output{
+			Address: address,
+			Coins:   outputsByAddress[address],
+		})
 	}
 	msg.Inputs = []banktypes.Input{{
 		Address: f.chainCtx.MustConvertToBech32Address(f.chainCtx.ClientContext.FromAddress()),


### PR DESCRIPTION
# Description

Existing Behavior: each funding request appended a new output directly, so a same address could appear multiple times in msg.Outputs. A practical safeguard is to avoid duplicate recipients in the same multisend batch.

The change: outputs are aggregated by address first, then, if the address repeats, it preserves the uniqueness of the address. if the address repeats, coins are merged with sdk.Coins.Add(...) and final msg.Outputs is built once per unique address.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/132)
<!-- Reviewable:end -->
