### PR TITLE
fix(dex - Certik): schedule both GoodTil delays when height and time are set

### DIFF
--- a/x/dex/keeper/good_til.go
+++ b/x/dex/keeper/good_til.go
@@ -41,10 +41,14 @@ func (k Keeper) delayGoodTilCancellation(
 	creator sdk.AccAddress,
 ) error {
 	if goodTil.GoodTilBlockHeight > 0 {
-		return k.delayGoodTilBlockHeightCancellation(ctx, goodTil.GoodTilBlockHeight, orderSequence, creator)
+		if err := k.delayGoodTilBlockHeightCancellation(ctx, goodTil.GoodTilBlockHeight, orderSequence, creator); err != nil {
+			return err
+		}
 	}
 	if goodTil.GoodTilBlockTime != nil {
-		return k.delayGoodTilBlockTimeCancellation(ctx, *goodTil.GoodTilBlockTime, orderSequence, creator)
+		if err := k.delayGoodTilBlockTimeCancellation(ctx, *goodTil.GoodTilBlockTime, orderSequence, creator); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/x/dex/keeper/good_til_test.go
+++ b/x/dex/keeper/good_til_test.go
@@ -528,8 +528,8 @@ func TestKeeper_GoodTil(t *testing.T) {
 			endHeight:   110,
 		},
 		{
-			// Regression for CertiK Submission #2: when both fields are set and the time boundary
-			// is reached first, the order is cancelled by the time path.
+			// Regression: when both fields are set and the time boundary is reached first,
+			// the order is cancelled by the time path.
 			name: "no_match_with_good_til_block_time_before_height_cancel_by_time",
 			orders: func(testSet TestSet) map[uint64][]types.Order {
 				return map[uint64][]types.Order{

--- a/x/dex/keeper/good_til_test.go
+++ b/x/dex/keeper/good_til_test.go
@@ -527,6 +527,39 @@ func TestKeeper_GoodTil(t *testing.T) {
 			startHeight: 100,
 			endHeight:   110,
 		},
+		{
+			// Regression for CertiK Submission #2: time-based delay must be
+			// scheduled even when height-based delay is also set. Time expires
+			// at block 103, height expires far past endHeight, so the order
+			// can only be cancelled by the time-based path.
+			name: "no_match_with_good_til_block_time_before_height_cancel_by_time",
+			orders: func(testSet TestSet) map[uint64][]types.Order {
+				return map[uint64][]types.Order{
+					101: {
+						{
+							Creator:    testSet.acc1.String(),
+							Type:       types.ORDER_TYPE_LIMIT,
+							ID:         "id1",
+							BaseDenom:  testSet.denom1,
+							QuoteDenom: testSet.denom2,
+							Price:      lo.ToPtr(types.MustNewPriceFromString("376e-3")),
+							Quantity:   quantity,
+							Side:       types.SIDE_SELL,
+							GoodTil: &types.GoodTil{
+								GoodTilBlockHeight: 200,
+								GoodTilBlockTime:   lo.ToPtr(initialBlockTime.Add(blockTime * time.Duration(3))),
+							},
+							TimeInForce: types.TIME_IN_FORCE_GTC,
+						},
+					},
+				}
+			},
+			wantOrders: func(testSet TestSet) []types.Order {
+				return []types.Order{}
+			},
+			startHeight: 100,
+			endHeight:   105,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/x/dex/keeper/good_til_test.go
+++ b/x/dex/keeper/good_til_test.go
@@ -528,10 +528,8 @@ func TestKeeper_GoodTil(t *testing.T) {
 			endHeight:   110,
 		},
 		{
-			// Regression for CertiK Submission #2: time-based delay must be
-			// scheduled even when height-based delay is also set. Time expires
-			// at block 103, height expires far past endHeight, so the order
-			// can only be cancelled by the time-based path.
+			// Regression for CertiK Submission #2: when both fields are set and the time boundary
+			// is reached first, the order is cancelled by the time path.
 			name: "no_match_with_good_til_block_time_before_height_cancel_by_time",
 			orders: func(testSet TestSet) map[uint64][]types.Order {
 				return map[uint64][]types.Order{
@@ -548,6 +546,37 @@ func TestKeeper_GoodTil(t *testing.T) {
 							GoodTil: &types.GoodTil{
 								GoodTilBlockHeight: 200,
 								GoodTilBlockTime:   lo.ToPtr(initialBlockTime.Add(blockTime * time.Duration(3))),
+							},
+							TimeInForce: types.TIME_IN_FORCE_GTC,
+						},
+					},
+				}
+			},
+			wantOrders: func(testSet TestSet) []types.Order {
+				return []types.Order{}
+			},
+			startHeight: 100,
+			endHeight:   105,
+		},
+		{
+			// Sanity check: when both fields are set and the height boundary is reached first,
+			// the order is cancelled by the height path.
+			name: "no_match_with_good_til_block_height_before_time_cancel_by_height",
+			orders: func(testSet TestSet) map[uint64][]types.Order {
+				return map[uint64][]types.Order{
+					101: {
+						{
+							Creator:    testSet.acc1.String(),
+							Type:       types.ORDER_TYPE_LIMIT,
+							ID:         "id1",
+							BaseDenom:  testSet.denom1,
+							QuoteDenom: testSet.denom2,
+							Price:      lo.ToPtr(types.MustNewPriceFromString("376e-3")),
+							Quantity:   quantity,
+							Side:       types.SIDE_SELL,
+							GoodTil: &types.GoodTil{
+								GoodTilBlockHeight: 103,
+								GoodTilBlockTime:   lo.ToPtr(initialBlockTime.Add(blockTime * time.Duration(100))),
 							},
 							TimeInForce: types.TIME_IN_FORCE_GTC,
 						},


### PR DESCRIPTION
Closes: https://app.clickup.com/t/868jnp17x

## Summary
`delayGoodTilCancellation` used an `if/return` chain that registered only the height-based delay when both `GoodTilBlockHeight` and `GoodTilBlockTime` were set on the same order. Orders then remained matchable past their declared `GoodTilBlockTime` until `GoodTilBlockHeight` was reached.

Replaced with parallel `if` blocks matching `removeGoodTilDelay`'s existing structure. Both delays are now scheduled when both fields are set; whichever fires first cancels the order, and the second cleanup becomes a no-op against the missing KV key.

Refs: CertiK Submission no:2 - accepted as Low severity.

## Test & Verification
- New regression test `no_match_with_good_til_block_time_before_height_cancel_by_time` exercises the time-before-height case (time expires at block 103, height set to 200, endHeight=105 — order can only be canceled via the time-based path).
- Full `TestKeeper_GoodTil` suite passes.
- Verified the new test fails without the fix (via `git stash` of `good_til.go`) — confirms it specifically guards against this regression and isn't a false positive.
# Description

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/137)
<!-- Reviewable:end -->
