### PR TITLE
fix(asset/ft): enforce maker compliance at DEX settlement

### DIFF
--- a/integration-tests/modules/dex_test.go
+++ b/integration-tests/modules/dex_test.go
@@ -2069,7 +2069,7 @@ func TestLimitOrdersMatchingWithAssetFTWhitelist(t *testing.T) {
 	requireT.NoError(err)
 	requireT.Equal(sdkmath.NewInt(33_000).String(), balanceRes.LockedInDEX.String())
 
-	// Reducing the whitelist limit will not interfere with DEX order after order placement
+	// Reducing the whitelist limit after order placement must take effect at settlement
 	msgSetWhitelistedLimit = &assetfttypes.MsgSetWhitelistedLimit{
 		Sender:  issuer.String(),
 		Account: acc2.String(),
@@ -2084,7 +2084,8 @@ func TestLimitOrdersMatchingWithAssetFTWhitelist(t *testing.T) {
 	)
 	requireT.NoError(err)
 
-	// place sell order to match the buy
+	// place sell order trying to match the buy - must be rejected at settlement
+	// because acc2's whitelist limit was lowered to 0 post-placement.
 	placeSellOrderMsg := &dextypes.MsgPlaceOrder{
 		Sender:      acc1.String(),
 		Type:        dextypes.ORDER_TYPE_LIMIT,
@@ -2103,31 +2104,11 @@ func TestLimitOrdersMatchingWithAssetFTWhitelist(t *testing.T) {
 		chain.TxFactoryAuto(),
 		placeSellOrderMsg,
 	)
-	requireT.NoError(err)
+	requireT.ErrorContains(err, assetfttypes.ErrDEXSettlementBlocked.Error())
 
-	assertBalance(ctx, t, bankClient, acc1, denom2, 11_000)
-	assertBalance(ctx, t, bankClient, acc2, denom1, 100_000)
-
-	// place order should succeed as issuer because admin (issuer) doesn't have whitelist limit
-	placeSellOrderMsg = &dextypes.MsgPlaceOrder{
-		Sender:      issuer.String(),
-		Type:        dextypes.ORDER_TYPE_LIMIT,
-		ID:          "id1",
-		BaseDenom:   denom1,
-		QuoteDenom:  denom2,
-		Price:       lo.ToPtr(dextypes.MustNewPriceFromString("1e-1")),
-		Quantity:    sdkmath.NewInt(100_000),
-		Side:        dextypes.SIDE_SELL,
-		TimeInForce: dextypes.TIME_IN_FORCE_GTC,
-	}
-
-	_, err = client.BroadcastTx(
-		ctx,
-		chain.ClientContext.WithFromAddress(issuer),
-		chain.TxFactoryAuto(),
-		placeSellOrderMsg,
-	)
-	requireT.NoError(err)
+	// whitelist invariant preserved; no tokens leaked to acc2.
+	assertBalance(ctx, t, bankClient, acc1, denom2, 0)
+	assertBalance(ctx, t, bankClient, acc2, denom1, 0)
 }
 
 // TestCancelOrdersByDenom tests the dex modules ability to cancel all orders of the account and by denom.

--- a/integration-tests/modules/dex_test.go
+++ b/integration-tests/modules/dex_test.go
@@ -1053,7 +1053,8 @@ func TestLimitOrdersMatchingWithAssetFTFreeze(t *testing.T) {
 	requireT.Equal(sdkmath.NewInt(150_000).String(), balanceRes.Frozen.String())
 	requireT.Equal(placeSellOrderMsg.Quantity.String(), balanceRes.LockedInDEX.String())
 
-	// place buy order to match the sell
+	// place buy order trying to match the sell - must be rejected at settlement
+	// because acc1's balance is fully frozen post-placement (Immunefi 77114 fix).
 	placeBuyOrderMsg := &dextypes.MsgPlaceOrder{
 		Sender:      acc2.String(),
 		Type:        dextypes.ORDER_TYPE_LIMIT,
@@ -1072,10 +1073,11 @@ func TestLimitOrdersMatchingWithAssetFTFreeze(t *testing.T) {
 		chain.TxFactoryAuto(),
 		placeBuyOrderMsg,
 	)
-	requireT.NoError(err)
+	requireT.ErrorContains(err, "DEX settlement: sender check failed")
 
-	assertBalance(ctx, t, bankClient, acc1, denom2, 10_000)
-	assertBalance(ctx, t, bankClient, acc2, denom1, 100_000)
+	// invariant balance >= frozen preserved; no tokens leaked to acc2.
+	assertBalance(ctx, t, bankClient, acc1, denom1, 150_000)
+	assertBalance(ctx, t, bankClient, acc2, denom1, 0)
 }
 
 // TestLimitOrdersMatchingWithAssetFTGloballyFreeze tests the dex modules ability to place get and match limit orders

--- a/integration-tests/modules/dex_test.go
+++ b/integration-tests/modules/dex_test.go
@@ -1073,7 +1073,7 @@ func TestLimitOrdersMatchingWithAssetFTFreeze(t *testing.T) {
 		chain.TxFactoryAuto(),
 		placeBuyOrderMsg,
 	)
-	requireT.ErrorContains(err, "DEX settlement: sender check failed")
+	requireT.ErrorContains(err, assetfttypes.ErrDEXSettlementBlocked.Error())
 
 	// invariant balance >= frozen preserved; no tokens leaked to acc2.
 	assertBalance(ctx, t, bankClient, acc1, denom1, 150_000)

--- a/x/asset/ft/keeper/keeper_dex.go
+++ b/x/asset/ft/keeper/keeper_dex.go
@@ -72,6 +72,9 @@ func (k Keeper) DEXExecuteActions(ctx sdk.Context, actions types.DEXActions) err
 			"to", send.ToAddress.String(),
 			"coin", send.Coin.String(),
 		)
+		if err := k.validateDEXSettlementSend(ctx, send); err != nil {
+			return err
+		}
 		if err := k.bankKeeper.SendCoins(ctx, send.FromAddress, send.ToAddress, sdk.NewCoins(send.Coin)); err != nil {
 			return sdkerrors.Wrap(err, "failed to DEX send coins")
 		}
@@ -642,6 +645,27 @@ func (k Keeper) updateDEXSettings(
 		return sdkerrors.Wrapf(types.ErrInvalidState, "failed to emit EventDEXSettingsChanged event: %s", err)
 	}
 
+	return nil
+}
+
+// validateDEXSettlementSend re-runs asset/ft compliance per settlement transfer.
+// k.bankKeeper is originalBankKeeper (no BeforeSendCoins) and DEXCheckOrderAmounts
+// only covers the taker, so maker-side freeze / whitelist / block_smart_contracts
+// changes between placement and match would otherwise be bypassed.
+func (k Keeper) validateDEXSettlementSend(ctx sdk.Context, send types.CoinToSend) error {
+	def, err := k.getDefinitionOrNil(ctx, send.Coin.Denom)
+	if err != nil {
+		return err
+	}
+	if def == nil {
+		return nil
+	}
+	if err := k.validateCoinSpendable(ctx, send.FromAddress, *def, send.Coin.Amount); err != nil {
+		return sdkerrors.Wrap(err, "DEX settlement: sender spendable check failed")
+	}
+	if err := k.validateCoinReceivable(ctx, send.ToAddress, *def, send.Coin.Amount); err != nil {
+		return sdkerrors.Wrap(err, "DEX settlement: recipient receivable check failed")
+	}
 	return nil
 }
 

--- a/x/asset/ft/keeper/keeper_dex.go
+++ b/x/asset/ft/keeper/keeper_dex.go
@@ -660,12 +660,62 @@ func (k Keeper) validateDEXSettlementSend(ctx sdk.Context, send types.CoinToSend
 	if def == nil {
 		return nil
 	}
-	if err := k.validateCoinSpendable(ctx, send.FromAddress, *def, send.Coin.Amount); err != nil {
-		return sdkerrors.Wrap(err, "DEX settlement: sender spendable check failed")
+	if err := k.validateSenderAtDEXSettlement(ctx, send.FromAddress, *def, send.Coin.Amount); err != nil {
+		return sdkerrors.Wrap(err, "DEX settlement: sender check failed")
 	}
 	if err := k.validateCoinReceivable(ctx, send.ToAddress, *def, send.Coin.Amount); err != nil {
-		return sdkerrors.Wrap(err, "DEX settlement: recipient receivable check failed")
+		return sdkerrors.Wrap(err, "DEX settlement: recipient check failed")
 	}
+	return nil
+}
+
+// validateSenderAtDEXSettlement re-checks sender compliance. The DEX-locked tokens
+// being transferred are not subtracted from available balance (unlike non-DEX sends
+// in validateCoinSpendable); per-account freeze is checked as balance - frozen >= amount.
+func (k Keeper) validateSenderAtDEXSettlement(
+	ctx sdk.Context,
+	addr sdk.AccAddress,
+	def types.Definition,
+	amount sdkmath.Int,
+) error {
+	if def.IsFeatureEnabled(types.Feature_freezing) {
+		isGloballyFrozen, err := k.isGloballyFrozen(ctx, def.Denom)
+		if err != nil {
+			return err
+		}
+		if isGloballyFrozen && !def.HasAdminPrivileges(addr) {
+			return sdkerrors.Wrapf(types.ErrGloballyFrozen, "%s is globally frozen", def.Denom)
+		}
+	}
+
+	if def.IsFeatureEnabled(types.Feature_block_smart_contracts) &&
+		!def.HasAdminPrivileges(addr) &&
+		cwasmtypes.IsTriggeredBySmartContract(ctx) {
+		return sdkerrors.Wrapf(
+			cosmoserrors.ErrUnauthorized,
+			"transfers made by smart contracts are disabled for %s",
+			def.Denom,
+		)
+	}
+
+	if def.IsFeatureEnabled(types.Feature_freezing) && !def.HasAdminPrivileges(addr) {
+		balance := k.bankKeeper.GetBalance(ctx, addr, def.Denom).Amount
+		frozenBalance, err := k.GetFrozenBalance(ctx, addr, def.Denom)
+		if err != nil {
+			return err
+		}
+		spendable := balance.Sub(frozenBalance.Amount)
+		if spendable.LT(amount) {
+			return sdkerrors.Wrapf(
+				cosmoserrors.ErrInsufficientFunds,
+				"%s%s is not spendable, %s%s frozen, %s%s available",
+				amount.String(), def.Denom,
+				frozenBalance.Amount.String(), def.Denom,
+				spendable.String(), def.Denom,
+			)
+		}
+	}
+
 	return nil
 }
 

--- a/x/asset/ft/keeper/keeper_dex.go
+++ b/x/asset/ft/keeper/keeper_dex.go
@@ -661,10 +661,10 @@ func (k Keeper) validateDEXSettlementSend(ctx sdk.Context, send types.CoinToSend
 		return nil
 	}
 	if err := k.validateSenderAtDEXSettlement(ctx, send.FromAddress, *def, send.Coin.Amount); err != nil {
-		return sdkerrors.Wrap(err, "DEX settlement: sender check failed")
+		return sdkerrors.Wrapf(types.ErrDEXSettlementBlocked, "sender check failed: %s", err)
 	}
 	if err := k.validateCoinReceivable(ctx, send.ToAddress, *def, send.Coin.Amount); err != nil {
-		return sdkerrors.Wrap(err, "DEX settlement: recipient check failed")
+		return sdkerrors.Wrapf(types.ErrDEXSettlementBlocked, "recipient check failed: %s", err)
 	}
 	return nil
 }

--- a/x/asset/ft/types/errors.go
+++ b/x/asset/ft/types/errors.go
@@ -29,4 +29,6 @@ var (
 	ErrDEXInsufficientSpendableBalance = sdkerrors.Register(
 		ModuleName, 11, "DEX insufficient spendable balance",
 	)
+	// ErrDEXSettlementBlocked is returned when asset/ft compliance rejects a transfer at DEX settlement.
+	ErrDEXSettlementBlocked = sdkerrors.Register(ModuleName, 12, "DEX settlement blocked")
 )

--- a/x/dex/keeper/keeper_ft_test.go
+++ b/x/dex/keeper/keeper_ft_test.go
@@ -640,7 +640,7 @@ func TestDEXSettlement_RejectsMatchAgainstFrozenMaker_Immunefi77114(t *testing.T
 		TimeInForce: types.TIME_IN_FORCE_GTC,
 	})
 	requireT.Error(err)
-	requireT.Contains(err.Error(), "DEX settlement: sender spendable check failed")
+	requireT.Contains(err.Error(), "DEX settlement: sender check failed")
 
 	// Invariant balance >= frozen holds; no tokens leaked to taker.
 	makerT := bankKeeper.GetBalance(sdkCtx, maker, tDenom).Amount

--- a/x/dex/keeper/keeper_ft_test.go
+++ b/x/dex/keeper/keeper_ft_test.go
@@ -639,8 +639,7 @@ func TestDEXSettlement_RejectsMatchAgainstFrozenMaker_Immunefi77114(t *testing.T
 		Quantity: sdkmath.NewInt(qty), Side: types.SIDE_BUY,
 		TimeInForce: types.TIME_IN_FORCE_GTC,
 	})
-	requireT.Error(err)
-	requireT.Contains(err.Error(), "DEX settlement: sender check failed")
+	requireT.ErrorIs(err, assetfttypes.ErrDEXSettlementBlocked)
 
 	// Invariant balance >= frozen holds; no tokens leaked to taker.
 	makerT := bankKeeper.GetBalance(sdkCtx, maker, tDenom).Amount

--- a/x/dex/keeper/keeper_ft_test.go
+++ b/x/dex/keeper/keeper_ft_test.go
@@ -571,3 +571,85 @@ func TestKeeper_PlaceOrderWithCommissionRate(t *testing.T) {
 	balanceAfterPlaceOrder := testApp.BankKeeper.GetBalance(sdkCtx, acc, denomWithCommissionRate)
 	require.Equal(t, balanceBeforePlaceOrder, balanceAfterPlaceOrder)
 }
+
+// Regression for Immunefi 77114: maker places SELL, issuer freezes maker, taker
+// attempts to match. Asserts settlement rejects the match with the spendable-check
+// error, maker's balance stays intact, taker receives nothing, and balance >= frozen.
+func TestDEXSettlement_RejectsMatchAgainstFrozenMaker_Immunefi77114(t *testing.T) {
+	requireT := require.New(t)
+
+	testApp := simapp.New()
+	sdkCtx := testApp.NewContextLegacy(false, tmproto.Header{
+		Height: 100,
+		Time:   time.Now(),
+	})
+
+	ftKeeper := testApp.AssetFTKeeper
+	bankKeeper := testApp.BankKeeper
+	dexKeeper := testApp.DEXKeeper
+
+	issuer, _ := testApp.GenAccount(sdkCtx)
+	maker, _ := testApp.GenAccount(sdkCtx)
+	taker, _ := testApp.GenAccount(sdkCtx)
+
+	tDenom, err := ftKeeper.Issue(sdkCtx, assetfttypes.IssueSettings{
+		Issuer:        issuer,
+		Symbol:        "TTT",
+		Subunit:       "ttt",
+		Precision:     6,
+		InitialAmount: sdkmath.NewIntWithDecimal(1, 18),
+		Features:      []assetfttypes.Feature{assetfttypes.Feature_freezing},
+	})
+	requireT.NoError(err)
+
+	qDenom, err := ftKeeper.Issue(sdkCtx, assetfttypes.IssueSettings{
+		Issuer:        issuer,
+		Symbol:        "QQQ",
+		Subunit:       "qqq",
+		Precision:     6,
+		InitialAmount: sdkmath.NewIntWithDecimal(1, 18),
+	})
+	requireT.NoError(err)
+
+	const qty int64 = 1_000_000
+	price := lo.ToPtr(types.MustNewPriceFromString("1"))
+
+	// Maker places SELL, locking qty T.
+	requireT.NoError(bankKeeper.SendCoins(sdkCtx, issuer, maker,
+		sdk.NewCoins(sdk.NewCoin(tDenom, sdkmath.NewInt(qty)))))
+	fundOrderReserve(t, testApp, sdkCtx, maker)
+	requireT.NoError(dexKeeper.PlaceOrder(sdkCtx, types.Order{
+		Creator: maker.String(), Type: types.ORDER_TYPE_LIMIT, ID: "sell",
+		BaseDenom: tDenom, QuoteDenom: qDenom, Price: price,
+		Quantity: sdkmath.NewInt(qty), Side: types.SIDE_SELL,
+		TimeInForce: types.TIME_IN_FORCE_GTC,
+	}))
+
+	// Issuer freezes maker's full T balance AFTER the order is placed.
+	requireT.NoError(ftKeeper.Freeze(sdkCtx, issuer, maker,
+		sdk.NewCoin(tDenom, sdkmath.NewInt(qty))))
+
+	// Unprivileged taker attempts to match — must be rejected by settlement check.
+	requireT.NoError(bankKeeper.SendCoins(sdkCtx, issuer, taker,
+		sdk.NewCoins(sdk.NewCoin(qDenom, sdkmath.NewInt(qty)))))
+	fundOrderReserve(t, testApp, sdkCtx, taker)
+	err = dexKeeper.PlaceOrder(sdkCtx, types.Order{
+		Creator: taker.String(), Type: types.ORDER_TYPE_LIMIT, ID: "buy",
+		BaseDenom: tDenom, QuoteDenom: qDenom, Price: price,
+		Quantity: sdkmath.NewInt(qty), Side: types.SIDE_BUY,
+		TimeInForce: types.TIME_IN_FORCE_GTC,
+	})
+	requireT.Error(err)
+	requireT.Contains(err.Error(), "DEX settlement: sender spendable check failed")
+
+	// Invariant balance >= frozen holds; no tokens leaked to taker.
+	makerT := bankKeeper.GetBalance(sdkCtx, maker, tDenom).Amount
+	takerT := bankKeeper.GetBalance(sdkCtx, taker, tDenom).Amount
+	frozen, err := ftKeeper.GetFrozenBalance(sdkCtx, maker, tDenom)
+	requireT.NoError(err)
+
+	requireT.Equal(sdkmath.NewInt(qty), makerT, "maker balance preserved")
+	requireT.Equal(sdkmath.ZeroInt(), takerT, "taker received nothing")
+	requireT.True(makerT.GTE(frozen.Amount),
+		"invariant holds: balance(%s) >= frozen(%s)", makerT, frozen.Amount)
+}

--- a/x/dex/keeper/keeper_matching_fuzz_test.go
+++ b/x/dex/keeper/keeper_matching_fuzz_test.go
@@ -494,6 +494,10 @@ func (fa *FuzzApp) PlaceOrder(t *testing.T, sdkCtx sdk.Context, order types.Orde
 		t.Logf("Placement failed, err: %s", err.Error())
 		creator := sdk.MustAccAddressFromBech32(order.Creator)
 		switch {
+		case sdkerrors.IsOf(err, assetfttypes.ErrDEXSettlementBlocked):
+			// Settlement-time maker-side compliance recheck.
+			t.Logf("Placement has failed due to settlement-time maker compliance: %v", err.Error())
+			return
 		case sdkerrors.IsOf(err, assetfttypes.ErrDEXInsufficientSpendableBalance):
 			// check that the order can't be placed because of the lack of balance
 			if order.Type != types.ORDER_TYPE_LIMIT {
@@ -572,8 +576,7 @@ func (fa *FuzzApp) PlaceOrder(t *testing.T, sdkCtx sdk.Context, order types.Orde
 			strings.Contains(err.Error(), "has to be multiple of quantity step"),
 			strings.Contains(err.Error(), "good til block"),
 			strings.Contains(err.Error(), "it's prohibited to save more than"),
-			strings.Contains(err.Error(), "not whitelisted for"), // whitelisted denoms
-			strings.Contains(err.Error(), "DEX settlement:"):     // maker-side compliance recheck (Immunefi 77114)
+			strings.Contains(err.Error(), "not whitelisted for"): // whitelisted denoms
 			t.Logf("Placement has failed due to expected error: %v", err.Error())
 			return
 		default:

--- a/x/dex/keeper/keeper_matching_fuzz_test.go
+++ b/x/dex/keeper/keeper_matching_fuzz_test.go
@@ -572,7 +572,8 @@ func (fa *FuzzApp) PlaceOrder(t *testing.T, sdkCtx sdk.Context, order types.Orde
 			strings.Contains(err.Error(), "has to be multiple of quantity step"),
 			strings.Contains(err.Error(), "good til block"),
 			strings.Contains(err.Error(), "it's prohibited to save more than"),
-			strings.Contains(err.Error(), "not whitelisted for"): // whitelisted denoms
+			strings.Contains(err.Error(), "not whitelisted for"), // whitelisted denoms
+			strings.Contains(err.Error(), "DEX settlement:"):     // maker-side compliance recheck (Immunefi 77114)
 			t.Logf("Placement has failed due to expected error: %v", err.Error())
 			return
 		default:


### PR DESCRIPTION
Closes: https://app.clickup.com/t/868jpxw8u

## Summary
Immunefi 77114 reported that DEX settlement bypassed asset/ft compliance hooks on the maker side: only the taker (`order.Creator`) was validated at match time, so freeze / whitelist / `block_smart_contracts` changes applied to a maker after order placement were silently ignored, letting frozen tokens drain out of the maker's account.

This PR re-runs `validateCoinSpendable` on the sender and `validateCoinReceivable` on the recipient of every settlement transfer in `DEXExecuteActions`, closing all three sibling exploits with one change. Regression test added in `x/dex/keeper/keeper_ft_test.go`.

## Context
- Immunefi report: https://bugs.immunefi.com/magnus/681/projects/208/reports/77114
- Severity / response (check title 77114): https://docs.google.com/document/d/1xfR0AqpIH6F4kPWF-tF9RD2pp2b4io5Ri0bdFybBgbA/edit?usp=sharing

## Integration test changes
`TestLimitOrdersMatchingWithAssetFTFreeze` and `TestLimitOrdersMatchingWithAssetFTWhitelist` were written assuming the buggy behavior was correct - with a comment that said "Reducing the whitelist limit
will not interfere with DEX order after order placement".
But this behavior is incorrect as reported in 77114: a maker places an order, the issuer freezes
or de-whitelists the account, and a taker can still drain the locked tokens.

With this fix the maker's freeze / whitelist state at match time is now respected, so those tests are updated to expect the match to be rejected and balances to stay intact. 

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/138)
<!-- Reviewable:end -->
