### PR TITLE
Prevent reward-pool poisoning by restricting deposits to the bond denom

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1159,6 +1159,7 @@ func New(
 			IBCKeeper:              app.IBCKeeper,
 			GovKeeper:              &app.GovKeeper,
 			FeeModelKeeper:         app.FeeModelKeeper,
+			StakingKeeper:          app.StakingKeeper,
 			WasmTXCounterStoreKey:  runtime.NewKVStoreService(keys[wasmtypes.StoreKey]),
 			WasmConfig:             wasmNodeConfig,
 		},

--- a/integration-tests/modules/reward_pool_poisoning_test.go
+++ b/integration-tests/modules/reward_pool_poisoning_test.go
@@ -1,0 +1,324 @@
+//go:build integrationtests
+
+package modules
+
+import (
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authztypes "github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+
+	integrationtests "github.com/tokenize-x/tx-chain/v8/integration-tests"
+	"github.com/tokenize-x/tx-chain/v8/pkg/client"
+	"github.com/tokenize-x/tx-chain/v8/testutil/integration"
+	assetfttypes "github.com/tokenize-x/tx-chain/v8/x/asset/ft/types"
+	customparamstypes "github.com/tokenize-x/tx-chain/v8/x/customparams/types"
+)
+
+// TestRewardPoolPoisoning verifies the fix that restricts validator reward-pool
+// deposits to the bond denom.
+//
+// The attack it guards against: depositing a whitelisting-enabled token into a
+// validator's reward pool poisons OutstandingRewards, so every later reward payout
+// fails and freezes all staking operations on that validator. The test asserts:
+//   - the poison deposit is rejected (directly and when wrapped in authz.MsgExec),
+//   - no poison denom enters OutstandingRewards,
+//   - all staking operations keep working (no freeze),
+//   - legitimate bond-denom deposits still succeed (no regression).
+//
+// On a vulnerable build the Phase 1 rejection assertions fail, so this test fails
+// without the fix and passes with it.
+func TestRewardPoolPoisoning(t *testing.T) {
+	t.Parallel()
+
+	ctx, chain := integrationtests.NewTXChainTestingContext(t)
+	requireT := require.New(t)
+	bankClient := banktypes.NewQueryClient(chain.ClientContext)
+	distrClient := distributiontypes.NewQueryClient(chain.ClientContext)
+	stakingClient := stakingtypes.NewQueryClient(chain.ClientContext)
+
+	issueFee := chain.QueryAssetFTParams(ctx, t).IssueFee
+	customParamsClient := customparamstypes.NewQueryClient(chain.ClientContext)
+	customStakingParams, err := customParamsClient.StakingParams(ctx, &customparamstypes.QueryStakingParamsRequest{})
+	requireT.NoError(err)
+	validatorStakingAmount := customStakingParams.Params.MinSelfDelegation.Mul(sdkmath.NewInt(2))
+
+	// --- Phase 0: Setup ---
+
+	attacker := chain.GenAccount()
+	delegator := chain.GenAccount()
+	// Delegate ~the validator self-stake so the delegator earns a non-zero reward share;
+	// a tiny delegation would round to zero against the large MinSelfDelegation.
+	delegateAmount := validatorStakingAmount
+	rewardSeedAmount := sdkmath.NewInt(10_000_000)
+
+	validator1AccAddr, validator1Addr, _, err := chain.CreateValidator(
+		ctx, t, validatorStakingAmount, validatorStakingAmount,
+	)
+	requireT.NoError(err)
+
+	// Second validator is the redelegation destination used in Phase 2.
+	_, validator2Addr, _, err := chain.CreateValidator(
+		ctx, t, validatorStakingAmount, validatorStakingAmount,
+	)
+	requireT.NoError(err)
+
+	chain.FundAccountWithOptions(ctx, t, delegator, integration.BalancesOptions{
+		Messages: []sdk.Msg{
+			&stakingtypes.MsgDelegate{},                     // initial delegation
+			&distributiontypes.MsgWithdrawDelegatorReward{}, // Phase 0 baseline withdraw
+			&distributiontypes.MsgWithdrawDelegatorReward{}, // Phase 2 withdraw
+			&stakingtypes.MsgDelegate{},                     // Phase 2 delegate more
+			&stakingtypes.MsgUndelegate{},                   // Phase 2 undelegate
+		},
+		// MsgBeginRedelegate (Phase 2) has non-deterministic gas, so it is funded here
+		// and broadcast with TxFactoryAuto rather than priced via GasLimitByMsgs.
+		NondeterministicMessagesGas: 500_000,
+		Amount:                      delegateAmount.MulRaw(3),
+	})
+
+	// Seeder makes the legitimate bond-denom deposits (Phase 0 seed + Phase 3 regression).
+	rewardSeeder := chain.GenAccount()
+	chain.FundAccountWithOptions(ctx, t, rewardSeeder, integration.BalancesOptions{
+		Messages: []sdk.Msg{
+			&distributiontypes.MsgDepositValidatorRewardsPool{},
+			&distributiontypes.MsgDepositValidatorRewardsPool{},
+		},
+		Amount: rewardSeedAmount.MulRaw(2),
+	})
+
+	delegateMsg := &stakingtypes.MsgDelegate{
+		DelegatorAddress: delegator.String(),
+		ValidatorAddress: validator1Addr.String(),
+		Amount:           chain.NewCoin(delegateAmount),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(delegator),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(delegateMsg)),
+		delegateMsg)
+	requireT.NoError(err)
+
+	// Seed a legitimate bond-denom reward so the delegator has rewards to withdraw.
+	depositBondDenomMsg := &distributiontypes.MsgDepositValidatorRewardsPool{
+		Depositor:        rewardSeeder.String(),
+		ValidatorAddress: validator1Addr.String(),
+		Amount:           sdk.NewCoins(chain.NewCoin(rewardSeedAmount)),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(rewardSeeder),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(depositBondDenomMsg)),
+		depositBondDenomMsg)
+	requireT.NoError(err)
+
+	requireT.NoError(client.AwaitNextBlocks(ctx, chain.ClientContext, 2))
+
+	// Baseline: delegator can withdraw a non-zero reward before the attack attempt.
+	delegatorBalBefore, err := bankClient.Balance(ctx, &banktypes.QueryBalanceRequest{
+		Address: delegator.String(), Denom: chain.ChainSettings.Denom,
+	})
+	requireT.NoError(err)
+
+	baselineWithdrawMsg := &distributiontypes.MsgWithdrawDelegatorReward{
+		DelegatorAddress: delegator.String(),
+		ValidatorAddress: validator1Addr.String(),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(delegator),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(baselineWithdrawMsg)),
+		baselineWithdrawMsg)
+	requireT.NoError(err)
+
+	delegatorBalAfter, err := bankClient.Balance(ctx, &banktypes.QueryBalanceRequest{
+		Address: delegator.String(), Denom: chain.ChainSettings.Denom,
+	})
+	requireT.NoError(err)
+	gasCost := chain.ComputeNeededBalanceFromOptions(integration.BalancesOptions{
+		Messages: []sdk.Msg{baselineWithdrawMsg},
+	})
+	baselineReward := delegatorBalAfter.Balance.Amount.Sub(delegatorBalBefore.Balance.Amount.Sub(gasCost))
+	requireT.True(baselineReward.IsPositive(), "baseline: delegator must have received non-zero rewards")
+	t.Logf("Baseline: withdrawal succeeded, reward: %s", baselineReward)
+
+	// --- Phase 1: the poison deposit must be REJECTED ---
+
+	chain.FundAccountWithOptions(ctx, t, attacker, integration.BalancesOptions{
+		Messages: []sdk.Msg{
+			&assetfttypes.MsgIssue{},
+			&assetfttypes.MsgSetWhitelistedLimit{},
+		},
+		Amount: issueFee.Amount,
+	})
+
+	issueMsg := &assetfttypes.MsgIssue{
+		Issuer:        attacker.String(),
+		Symbol:        "POISON",
+		Subunit:       "upoison",
+		Precision:     6,
+		Description:   "Reward pool poisoning token",
+		InitialAmount: sdkmath.NewInt(1_000_000_000),
+		Features:      []assetfttypes.Feature{assetfttypes.Feature_whitelisting},
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(attacker),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(issueMsg)),
+		issueMsg)
+	requireT.NoError(err)
+	poisonDenom := assetfttypes.BuildDenom(issueMsg.Subunit, attacker)
+
+	// Whitelisting the distribution module is what let the poison settle in pre-fix.
+	distributionModuleAddr := authtypes.NewModuleAddress(distributiontypes.ModuleName)
+	whitelistMsg := &assetfttypes.MsgSetWhitelistedLimit{
+		Sender:  attacker.String(),
+		Account: distributionModuleAddr.String(),
+		Coin:    sdk.NewInt64Coin(poisonDenom, 1_000_000_000),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(attacker),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(whitelistMsg)),
+		whitelistMsg)
+	requireT.NoError(err)
+
+	poisonDeposit := &distributiontypes.MsgDepositValidatorRewardsPool{
+		Depositor:        attacker.String(),
+		ValidatorAddress: validator1Addr.String(),
+		Amount:           sdk.NewCoins(sdk.NewInt64Coin(poisonDenom, 1_000_000)),
+	}
+
+	// 1a. Direct poison deposit is rejected by the ante decorator.
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(attacker),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(poisonDeposit)),
+		poisonDeposit)
+	requireT.Error(err)
+	requireT.ErrorContains(err, "only the bond denom")
+	t.Log("Direct poison deposit rejected: only the bond denom is accepted")
+
+	// 1b. Poison deposit wrapped in authz.MsgExec is ALSO rejected (bypass closed).
+	execMsg := authztypes.NewMsgExec(attacker, []sdk.Msg{poisonDeposit})
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(attacker),
+		chain.TxFactory().WithGas(400_000),
+		&execMsg)
+	requireT.Error(err)
+	requireT.ErrorContains(err, "only the bond denom")
+	t.Log("authz-wrapped poison deposit rejected: bypass closed")
+
+	// No poison denom ever entered the validator's outstanding rewards.
+	requireT.NoError(client.AwaitNextBlocks(ctx, chain.ClientContext, 1))
+	outstandingResp, err := distrClient.ValidatorOutstandingRewards(ctx,
+		&distributiontypes.QueryValidatorOutstandingRewardsRequest{
+			ValidatorAddress: validator1Addr.String(),
+		})
+	requireT.NoError(err)
+	requireT.True(outstandingResp.Rewards.Rewards.AmountOf(poisonDenom).IsZero(),
+		"no poison denom must be present in outstanding rewards")
+	t.Log("OutstandingRewards clean: no poison denom present")
+
+	// --- Phase 2: all staking operations keep working (no freeze) ---
+
+	// 1. Delegator can withdraw rewards.
+	withdrawMsg := &distributiontypes.MsgWithdrawDelegatorReward{
+		DelegatorAddress: delegator.String(),
+		ValidatorAddress: validator1Addr.String(),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(delegator),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(withdrawMsg)),
+		withdrawMsg)
+	requireT.NoError(err)
+
+	// 2. Delegator can delegate more.
+	delegateMoreMsg := &stakingtypes.MsgDelegate{
+		DelegatorAddress: delegator.String(),
+		ValidatorAddress: validator1Addr.String(),
+		Amount:           chain.NewCoin(sdkmath.NewInt(1)),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(delegator),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(delegateMoreMsg)),
+		delegateMoreMsg)
+	requireT.NoError(err)
+
+	// 3. Delegator can redelegate to validator 2.
+	redelegateMsg := &stakingtypes.MsgBeginRedelegate{
+		DelegatorAddress:    delegator.String(),
+		ValidatorSrcAddress: validator1Addr.String(),
+		ValidatorDstAddress: validator2Addr.String(),
+		Amount:              chain.NewCoin(sdkmath.NewInt(100)),
+	}
+	// MsgBeginRedelegate is non-deterministic gas on tx-chain → use TxFactoryAuto.
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(delegator),
+		chain.TxFactoryAuto(),
+		redelegateMsg)
+	requireT.NoError(err)
+
+	// 4. Delegator can undelegate.
+	undelegateMsg := &stakingtypes.MsgUndelegate{
+		DelegatorAddress: delegator.String(),
+		ValidatorAddress: validator1Addr.String(),
+		Amount:           chain.NewCoin(sdkmath.NewInt(100)),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(delegator),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(undelegateMsg)),
+		undelegateMsg)
+	requireT.NoError(err)
+
+	// 5. Validator can withdraw commission.
+	chain.FundAccountWithOptions(ctx, t, validator1AccAddr, integration.BalancesOptions{
+		Messages: []sdk.Msg{
+			&distributiontypes.MsgWithdrawValidatorCommission{},
+			&stakingtypes.MsgUndelegate{},
+		},
+		Amount: sdkmath.NewInt(1),
+	})
+	commissionMsg := &distributiontypes.MsgWithdrawValidatorCommission{
+		ValidatorAddress: validator1Addr.String(),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(validator1AccAddr),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(commissionMsg)),
+		commissionMsg)
+	requireT.NoError(err)
+
+	// 6. Validator can self-undelegate.
+	selfUndelegateMsg := &stakingtypes.MsgUndelegate{
+		DelegatorAddress: validator1AccAddr.String(),
+		ValidatorAddress: validator1Addr.String(),
+		Amount:           chain.NewCoin(sdkmath.NewInt(1)),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(validator1AccAddr),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(selfUndelegateMsg)),
+		selfUndelegateMsg)
+	requireT.NoError(err)
+	t.Log("All 6 operations succeeded: withdraw, delegate, redelegate, undelegate, commission, self-undelegate")
+
+	// --- Phase 3: legitimate bond-denom deposits still work (no regression) ---
+
+	depositBondDenomMsg2 := &distributiontypes.MsgDepositValidatorRewardsPool{
+		Depositor:        rewardSeeder.String(),
+		ValidatorAddress: validator1Addr.String(),
+		Amount:           sdk.NewCoins(chain.NewCoin(rewardSeedAmount)),
+	}
+	_, err = client.BroadcastTx(ctx,
+		chain.ClientContext.WithFromAddress(rewardSeeder),
+		chain.TxFactory().WithGas(chain.GasLimitByMsgs(depositBondDenomMsg2)),
+		depositBondDenomMsg2)
+	requireT.NoError(err)
+	t.Log("Legitimate bond-denom reward-pool deposit still succeeds")
+
+	// Sanity: validator still queryable with positive tokens.
+	val1Resp, err := stakingClient.Validator(ctx, &stakingtypes.QueryValidatorRequest{
+		ValidatorAddr: validator1Addr.String(),
+	})
+	requireT.NoError(err)
+	requireT.True(val1Resp.Validator.Tokens.IsPositive(), "validator must retain its tokens")
+}

--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -31,6 +31,7 @@ type HandlerOptions struct {
 	WasmConfig             wasmtypes.NodeConfig
 	IBCKeeper              *ibckeeper.Keeper
 	GovKeeper              *govkeeper.Keeper
+	StakingKeeper          StakingKeeper
 	WasmTXCounterStoreKey  store.KVStoreService
 }
 
@@ -56,6 +57,10 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 
 	if options.GovKeeper == nil {
 		return nil, sdkerrors.Wrap(cosmoserrors.ErrLogic, "gov keeper is required for ante builder")
+	}
+
+	if options.StakingKeeper == nil {
+		return nil, sdkerrors.Wrap(cosmoserrors.ErrLogic, "staking keeper is required for ante builder")
 	}
 
 	if options.SignModeHandler == nil {
@@ -109,6 +114,8 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		deterministicgasante.NewSetInfiniteGasMeterDecorator(options.DeterministicGasConfig),
 		authante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		authante.NewValidateBasicDecorator(),
+		// Restrict validator reward-pool deposits to the bond denom.
+		NewDepositValidatorRewardsPoolDenomDecorator(options.StakingKeeper),
 		authante.NewTxTimeoutHeightDecorator(),
 		// after setup context to enforce limits early
 		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit),

--- a/x/auth/ante/deposit_rewards_pool.go
+++ b/x/auth/ante/deposit_rewards_pool.go
@@ -1,0 +1,86 @@
+package ante
+
+import (
+	"context"
+
+	sdkerrors "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	cosmoserrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+)
+
+// StakingKeeper defines the expected staking keeper used to resolve the bond denom.
+type StakingKeeper interface {
+	BondDenom(ctx context.Context) (string, error)
+}
+
+// DepositValidatorRewardsPoolDenomDecorator restricts MsgDepositValidatorRewardsPool
+// to the chain's bond denom.
+//
+// Allowing arbitrary denoms lets an attacker deposit a token with receive-side
+// restrictions (e.g. whitelisting) into a validator's reward pool, which can cause
+// reward payout fails and freezing all staking operations on that validator.
+// The bond denom carries no such features.
+type DepositValidatorRewardsPoolDenomDecorator struct {
+	stakingKeeper StakingKeeper
+}
+
+// NewDepositValidatorRewardsPoolDenomDecorator creates a new DepositValidatorRewardsPoolDenomDecorator.
+func NewDepositValidatorRewardsPoolDenomDecorator(
+	stakingKeeper StakingKeeper,
+) DepositValidatorRewardsPoolDenomDecorator {
+	return DepositValidatorRewardsPoolDenomDecorator{stakingKeeper: stakingKeeper}
+}
+
+// AnteHandle rejects any MsgDepositValidatorRewardsPool carrying a non-bond denom.
+func (d DepositValidatorRewardsPoolDenomDecorator) AnteHandle(
+	ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler,
+) (sdk.Context, error) {
+	deposits := collectDepositValidatorRewardsPoolMsgs(tx.GetMsgs())
+	if len(deposits) == 0 {
+		return next(ctx, tx, simulate)
+	}
+
+	bondDenom, err := d.stakingKeeper.BondDenom(ctx)
+	if err != nil {
+		return ctx, err
+	}
+
+	for _, deposit := range deposits {
+		for _, coin := range deposit.Amount {
+			if coin.Denom != bondDenom {
+				return ctx, sdkerrors.Wrapf(
+					cosmoserrors.ErrInvalidRequest,
+					"only the bond denom %q can be deposited into validator reward pools, got %q",
+					bondDenom, coin.Denom,
+				)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// collectDepositValidatorRewardsPoolMsgs returns all MsgDepositValidatorRewardsPool
+// messages in the tx, unwrapping authz.MsgExec recursively so the restriction
+// cannot be bypassed by nesting the deposit inside an authz exec.
+func collectDepositValidatorRewardsPoolMsgs(
+	msgs []sdk.Msg,
+) []*distributiontypes.MsgDepositValidatorRewardsPool {
+	var deposits []*distributiontypes.MsgDepositValidatorRewardsPool
+	for _, msg := range msgs {
+		switch typedMsg := msg.(type) {
+		case *distributiontypes.MsgDepositValidatorRewardsPool:
+			deposits = append(deposits, typedMsg)
+		case *authz.MsgExec:
+			nested, err := typedMsg.GetMessages()
+			if err != nil {
+				// Malformed nested messages are rejected later by the authz handler.
+				continue
+			}
+			deposits = append(deposits, collectDepositValidatorRewardsPoolMsgs(nested)...)
+		}
+	}
+	return deposits
+}

--- a/x/auth/ante/deposit_rewards_pool_test.go
+++ b/x/auth/ante/deposit_rewards_pool_test.go
@@ -1,0 +1,74 @@
+package ante
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCollectDepositValidatorRewardsPoolMsgs checks deposits are found whether
+// submitted directly or nested (recursively) inside authz.MsgExec, so the denom
+// restriction cannot be bypassed by wrapping the deposit in an authz exec.
+func TestCollectDepositValidatorRewardsPoolMsgs(t *testing.T) {
+	addr := sdk.AccAddress("test_address________")
+
+	deposit := &distributiontypes.MsgDepositValidatorRewardsPool{
+		Depositor:        addr.String(),
+		ValidatorAddress: sdk.ValAddress(addr).String(),
+		Amount:           sdk.NewCoins(sdk.NewInt64Coin("upoison", 1_000_000)),
+	}
+	otherMsg := &banktypes.MsgSend{FromAddress: addr.String(), ToAddress: addr.String()}
+
+	authzWrap := func(msgs ...sdk.Msg) sdk.Msg {
+		exec := authz.NewMsgExec(addr, msgs)
+		return &exec
+	}
+
+	testCases := []struct {
+		name      string
+		msgs      []sdk.Msg
+		wantCount int
+	}{
+		{
+			name:      "direct deposit",
+			msgs:      []sdk.Msg{deposit},
+			wantCount: 1,
+		},
+		{
+			name:      "no deposit",
+			msgs:      []sdk.Msg{otherMsg},
+			wantCount: 0,
+		},
+		{
+			name:      "deposit wrapped in authz.MsgExec",
+			msgs:      []sdk.Msg{authzWrap(deposit)},
+			wantCount: 1,
+		},
+		{
+			name:      "deposit double-wrapped in authz.MsgExec",
+			msgs:      []sdk.Msg{authzWrap(authzWrap(deposit))},
+			wantCount: 1,
+		},
+		{
+			name:      "deposit alongside unrelated msg inside authz.MsgExec",
+			msgs:      []sdk.Msg{authzWrap(otherMsg, deposit)},
+			wantCount: 1,
+		},
+		{
+			name:      "multiple deposits direct and nested",
+			msgs:      []sdk.Msg{deposit, authzWrap(deposit), otherMsg},
+			wantCount: 2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := collectDepositValidatorRewardsPoolMsgs(tc.msgs)
+			require.Len(t, got, tc.wantCount)
+		})
+	}
+}


### PR DESCRIPTION
Closes: https://app.clickup.com/t/868k3j4u1
Ref: https://bugs.immunefi.com/magnus/681/projects/208/reports/71661

## Description
`MsgDepositValidatorRewardsPool` accepted any denom. An attacker could issue an Asset FT with the whitelisting feature and deposit it into a validator's reward pool, poisoning `OutstandingRewards`. The attacker whitelists only the distribution module so the deposit lands, but reward recipients (delegators and the validator) are not whitelisted - so every reward payout fails on the whitelisting check and reverts. This permanently freezes all staking operations
on that validator (withdraw, delegate, undelegate, redelegate, commission), with no on-chain recovery and repeatable per validator.

Attack flow: `attacker → issue whitelisting Asset FT → whitelist only distribution module → deposit token into validator reward pool → poisons OutstandingRewards → payout to non-whitelisted delegators/validator fails → all staking ops revert`

## Fix
An ante decorator rejects reward-pool deposits in any denom other than the bond denom (e.g. `ucore` in mainnet). It also unwraps `authz.MsgExec` so the check can't be bypassed. Legitimate native-token deposits are unaffected.

## Test
- Unit: verifies the deposit-collection finds `MsgDepositValidatorRewardsPool` whether sent directly or hidden inside `authz.MsgExec` (including nested and mixed with other messages), so the bond-denom check can't be bypassed via `authz`.
- Integration: reproduces the attack and asserts poison deposits are rejected, no poison enters `OutstandingRewards`, all staking ops keep working, and legitimate deposits still succeed - fails without the fix, passes with it.

# Reviewers checklist:
- [ ] Try to write more meaningful comments with clear actions to be taken.
- [ ] Nit-picking should be unblocking. Focus on core issues.

# Authors checklist
- [ ] Provide a concise and meaningful description
- [ ] Review the code yourself first, before making the PR.
- [ ] Annotate your PR in places that require explanation.
- [ ] Think and try to split the PR to smaller PR if it is big.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tokenize-x/tx-chain/139)
<!-- Reviewable:end -->
